### PR TITLE
Fix sbt output coloring

### DIFF
--- a/docs/docs/docs/LibraryIntegrations.md
+++ b/docs/docs/docs/LibraryIntegrations.md
@@ -34,7 +34,14 @@ Add this to your SBT build
 "com.github.jatcwang" %% "difflicious-scalatest" % "{{ site.version }}" % Test
 ```
 
-and then in your test suites you can call `assertNoDiff` on any `Differ`.
+Tests should be run with the `-oW` option to disable Scalatest from coloring test failures all red as it interferes with 
+difflicious color display.
+
+```
+testOnly -- -oW
+```
+
+Here's an example of what a test using difflicious looks like:
 
 ```scala mdoc:nest
 import org.scalatest.funsuite.AnyFunSuite

--- a/modules/core/src/main/scala/difflicious/differ/TransformedDiffer.scala
+++ b/modules/core/src/main/scala/difflicious/differ/TransformedDiffer.scala
@@ -1,9 +1,9 @@
 package difflicious.differ
 
-import difflicious.{DiffResult, ConfigureOp, ConfigureError, ConfigurePath, DiffInput}
+import difflicious.{ConfigureError, ConfigureOp, ConfigurePath, DiffInput, DiffResult}
 
 /**
-  * A Differ that transforms any input of [[diff]] method and pass it to its underlying Differ.
+  * A Differ that transforms any input of diff method and pass it to its underlying Differ.
   * See [[ValueDiffer.contramap]]
   */
 class TransformedDiffer[T, U](underlyingDiffer: ValueDiffer[U], transformFunc: T => U) extends ValueDiffer[T] {

--- a/modules/coretest/src/test/scala/difflicious/testutils/package.scala
+++ b/modules/coretest/src/test/scala/difflicious/testutils/package.scala
@@ -3,7 +3,7 @@ package difflicious
 import difflicious.DiffResultPrinter.consoleOutput
 import munit.Assertions.assertEquals
 import org.scalacheck.Prop.{forAll, propBoolean}
-import org.scalacheck.{Prop, Arbitrary}
+import org.scalacheck.{Arbitrary, Prop}
 import difflicious.internal.EitherGetSyntax._
 
 package object testutils {
@@ -51,7 +51,17 @@ package object testutils {
     res: DiffResult,
     expectedOutputStr: String,
   ): Unit = {
-    val obtainedOutputStr = consoleOutput(res, 0).render
+
+    // Reverse "recolor each line" difflicious.DiffResultPrinter.colorOnMatchType
+    // to make test expectations easier to read and write
+    def removeMultilineRecoloring(str: String): String = {
+      val k = s"$X\n $R"
+      val j = s"$X\n $G"
+      val replaced = str.replace(k, "\n ").replace(j, "\n ")
+      replaced
+    }
+
+    val obtainedOutputStr = removeMultilineRecoloring(consoleOutput(res, 0).render)
 
     if (obtainedOutputStr != expectedOutputStr) {
       println("=== Obtained Output === ")


### PR DESCRIPTION
SBT puts a [info] prefix on the output of the tests framework which resets the color each line, therefore this commits ensures that every line in difflicious rendered string is recolored.

Fixes #6