### PR TITLE
fix: Migrate to use ruby/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Setup ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
 
@@ -130,7 +130,7 @@ jobs:
           rm targets.tar
 
       - name: Setup ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
 

--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,7 @@ ThisBuild / githubWorkflowPublish := Seq(
 
 val setupJekyllSteps = Seq(
   WorkflowStep.Use(
-    UseRef.Public("actions", "setup-ruby", "v1"),
+    UseRef.Public("ruby", "setup-ruby", "v1"),
     name = Some("Setup ruby"),
     params = Map("ruby-version" -> "2.7"),
   ),


### PR DESCRIPTION
actions/setup-ruby@v1 is deprecated: https://github.com/actions/setup-ruby