### PR TITLE
Add integration for Weaver test framework

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ import sbtghactions.JavaSpec
 val munitVersion = "0.7.29"
 val catsVersion = "2.7.0"
 val scalatestVersion = "3.2.11"
+val weaverVersion = "0.8.3"
 
 val scala213 = "2.13.8"
 val scala3 = "3.1.1"
@@ -31,7 +32,7 @@ inThisBuild(
 )
 
 lazy val difflicious = Project("difflicious", file("."))
-  .aggregate(core, coretest, benchmarks, cats, docs, munit, scalatest)
+  .aggregate(core, coretest, benchmarks, cats, docs, munit, scalatest, weaver)
   .settings(commonSettings, noPublishSettings)
 
 lazy val core = Project("difflicious-core", file("modules/core"))
@@ -72,6 +73,15 @@ lazy val scalatest = Project("difflicious-scalatest", file("modules/scalatest"))
     ),
   )
 
+lazy val weaver = Project("difflicious-weaver", file("modules/weaver"))
+  .dependsOn(core)
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.disneystreaming" %% "weaver-core" % weaverVersion,
+    ),
+  )
+
 lazy val cats = Project("difflicious-cats", file("modules/cats"))
   .dependsOn(core, coretest % "test->test")
   .settings(commonSettings)
@@ -99,7 +109,7 @@ lazy val coretest = Project("coretest", file("modules/coretest"))
   )
 
 lazy val docs: Project = project
-  .dependsOn(core, coretest, cats, munit, scalatest)
+  .dependsOn(core, coretest, cats, munit, scalatest, weaver)
   .enablePlugins(MicrositesPlugin)
   .settings(
     commonSettings,
@@ -108,6 +118,7 @@ lazy val docs: Project = project
   .settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % scalatestVersion,
+      "com.disneystreaming" %% "weaver-cats" % weaverVersion,
     ),
     makeMicrosite := Def.taskDyn {
       val orig = (ThisProject / makeMicrosite).taskValue

--- a/docs/docs/docs/LibraryIntegrations.md
+++ b/docs/docs/docs/LibraryIntegrations.md
@@ -55,6 +55,27 @@ class MyTest extends AnyFunSuite {
 }
 ```
 
+## Weaver
+
+Add this to your SBT build
+```
+"com.github.jatcwang" %% "difflicious-weaver" % "{{ site.version }}" % Test
+```
+
+and then in your test suites you can call `assertNoDiff` on any `Differ`.
+
+```scala mdoc:nest
+import weaver.SimpleIOSuite
+import difflicious.weaver.WeaverDiff._
+import difflicious.Differ
+
+object MyTest extends SimpleIOSuite {
+  pureTest("a == b") { 
+    Differ[Int].assertNoDiff(1, 2)
+  }
+}
+```
+
 ## Cats
 
 Differ instances for cats data structures like `NonEmptyList` and `Chain` can be found in

--- a/modules/weaver/src/main/scala-2.13/difflicious/weaver/WeaverDiff.scala
+++ b/modules/weaver/src/main/scala-2.13/difflicious/weaver/WeaverDiff.scala
@@ -1,0 +1,17 @@
+package difflicious.weaver
+
+import difflicious.{Differ, DiffResultPrinter}
+import weaver.{Expectations, SourceLocation}
+import weaver.Expectations.Helpers.{failure, success}
+
+trait WeaverDiff {
+  implicit class DifferExtensions[A](differ: Differ[A]) {
+    def assertNoDiff(obtained: A, expected: A)(implicit pos: SourceLocation): Expectations = {
+      val result = differ.diff(obtained, expected)
+      if (!result.isOk) failure(DiffResultPrinter.consoleOutput(result, 0).render)
+      else success
+    }
+  }
+}
+
+object WeaverDiff extends WeaverDiff

--- a/modules/weaver/src/main/scala-3/difflicious.weaver/WeaverDiff.scala
+++ b/modules/weaver/src/main/scala-3/difflicious.weaver/WeaverDiff.scala
@@ -1,0 +1,16 @@
+package difflicious.weaver
+
+import difflicious.{Differ, DiffResultPrinter}
+import weaver.Expectations
+import weaver.Expectations.Helpers.{failure, success}
+
+trait WeaverDiff {
+  extension [A](differ: Differ[A])
+    inline def assertNoDiff(obtained: A, expected: A): Expectations = {
+      val result = differ.diff(obtained, expected)
+      if (!result.isOk) failure(DiffResultPrinter.consoleOutput(result, 0).render)
+      else success
+    }
+}
+
+object WeaverDiff extends WeaverDiff


### PR DESCRIPTION
hello, thanks for this project.

With this PR we are adding support for the `weaver` framework and I followed the structure of the [scalatest](https://github.com/jatcwang/difflicious/tree/master/modules/scalatest/src/main) module. 
I didn't open an issue before as I think this is a small change.