### PR TITLE
Approximate element pairing for sets

### DIFF
--- a/modules/core/src/main/scala/difflicious/DiffResult.scala
+++ b/modules/core/src/main/scala/difflicious/DiffResult.scala
@@ -6,24 +6,31 @@ import scala.collection.immutable.ListMap
 
 sealed trait DiffResult {
 
-  /**
-    * Whether this DiffResult was produced from an ignored Differ
+  /** Whether this DiffResult was produced from an ignored Differ
     * @return
     */
   def isIgnored: Boolean
 
-  /**
-    * Whether this DiffResult is consider "successful".
-    * If there are any non-ignored differences found, then this should be false
+  /** Whether this DiffResult is consider "successful". If there are any non-ignored differences found, then this should
+    * be false
     * @return
     */
   def isOk: Boolean
 
-  /**
-    * Whether the input leading to this DiffResult has both sides or just one.
+  /** Whether the input leading to this DiffResult has both sides or just one.
     * @return
     */
   def pairType: PairType
+
+  /** The number of differences found, regardless of if they were ignored or not
+    * @return
+    */
+  def differenceCount: Int
+
+  /** The number of ignored differences
+    * @return
+    */
+  def ignoredCount: Int
 }
 
 object DiffResult {
@@ -33,6 +40,8 @@ object DiffResult {
     pairType: PairType,
     isIgnored: Boolean,
     isOk: Boolean,
+    differenceCount: Int,
+    ignoredCount: Int,
   ) extends DiffResult
 
   final case class RecordResult(
@@ -41,6 +50,8 @@ object DiffResult {
     pairType: PairType,
     isIgnored: Boolean,
     isOk: Boolean,
+    differenceCount: Int,
+    ignoredCount: Int,
   ) extends DiffResult
 
   final case class MapResult(
@@ -49,6 +60,8 @@ object DiffResult {
     pairType: PairType,
     isIgnored: Boolean,
     isOk: Boolean,
+    differenceCount: Int,
+    ignoredCount: Int,
   ) extends DiffResult
 
   object MapResult {
@@ -64,6 +77,8 @@ object DiffResult {
     isIgnored: Boolean,
   ) extends DiffResult {
     override def isOk: Boolean = isIgnored
+    override def differenceCount: Int = 1
+    override def ignoredCount: Int = 1
   }
 
   sealed trait ValueResult extends DiffResult
@@ -72,14 +87,20 @@ object DiffResult {
     final case class Both(obtained: String, expected: String, isSame: Boolean, isIgnored: Boolean) extends ValueResult {
       override def pairType: PairType = PairType.Both
       override def isOk: Boolean = isIgnored || isSame
+      override def differenceCount: Int = if (isSame) 0 else 1
+      override def ignoredCount: Int = if (!isSame && isIgnored) 1 else 0
     }
     final case class ObtainedOnly(obtained: String, isIgnored: Boolean) extends ValueResult {
       override def pairType: PairType = PairType.ObtainedOnly
       override def isOk: Boolean = false
+      override def differenceCount: Int = 1
+      override def ignoredCount: Int = if (isIgnored) 1 else 0
     }
     final case class ExpectedOnly(expected: String, isIgnored: Boolean) extends ValueResult {
       override def pairType: PairType = PairType.ExpectedOnly
       override def isOk: Boolean = false
+      override def differenceCount: Int = 1
+      override def ignoredCount: Int = if (isIgnored) 1 else 0
     }
   }
 

--- a/modules/core/src/main/scala/difflicious/PairingFn.scala
+++ b/modules/core/src/main/scala/difflicious/PairingFn.scala
@@ -1,0 +1,38 @@
+package difflicious
+
+sealed trait PairingFn[A, B] {
+  def fn: A => B
+  def matching(a1: A, a2: A)(differ: Differ[A]): Boolean
+}
+
+object PairingFn {
+  def lift[A, B](fn: A => B): PairingFn[A, B] = UsingEquals(fn)
+
+  def approximate[A](threshold: Int): PairingFn[A, A] =
+    Approximate(identity, differenceCountThreshold = threshold)
+
+  case class UsingEquals[A, B](fn: A => B) extends PairingFn[A, B] {
+    override def matching(a1: A, a2: A)(differ: Differ[A]): Boolean = fn(a1) == fn(a2)
+  }
+
+  sealed trait DifferBased[A, B] extends PairingFn[A, B] {
+    def fn: A => B
+    def differenceCountThreshold: Int
+  }
+
+  case class Approximate[A](fn: A => A, differenceCountThreshold: Int) extends DifferBased[A, A] {
+    override def matching(a1: A, a2: A)(differ: Differ[A]): Boolean = {
+      val diffResult = differ.diff(fn(a1), fn(a2))
+
+      diffResult.differenceCount - diffResult.ignoredCount <= differenceCountThreshold
+    }
+  }
+
+  case class Custom[A, B](fn: A => B, differenceCountThreshold: Int, pairDiffer: Differ[B]) extends DifferBased[A, B] {
+    override def matching(a1: A, a2: A)(differ: Differ[A]): Boolean = {
+      val diffResult = pairDiffer.diff(fn(a1), fn(a2))
+
+      diffResult.differenceCount - diffResult.ignoredCount <= differenceCountThreshold
+    }
+  }
+}

--- a/modules/core/src/main/scala/difflicious/differ/SeqDiffer.scala
+++ b/modules/core/src/main/scala/difflicious/differ/SeqDiffer.scala
@@ -3,8 +3,9 @@ package difflicious.differ
 import difflicious.DiffResult.ListResult
 import difflicious.utils.SeqLike
 import difflicious.ConfigureOp.PairBy
-import difflicious.{Differ, DiffResult, ConfigureOp, ConfigureError, ConfigurePath, DiffInput, PairType}
+import difflicious.{ConfigureError, ConfigureOp, ConfigurePath, DiffInput, DiffResult, Differ, PairType}
 import SeqDiffer.diffPairByFunc
+import difflicious.internal.SumCountsSyntax.DiffResultIterableOps
 import difflicious.utils.TypeName.SomeTypeName
 
 import scala.collection.mutable
@@ -45,6 +46,8 @@ final class SeqDiffer[F[_], A](
             pairType = PairType.Both,
             isIgnored = isIgnored,
             isOk = isIgnored || diffResults.forall(_.isOk),
+            differenceCount = diffResults.differenceCount,
+            ignoredCount = diffResults.ignoredCount,
           )
         }
         case PairBy.ByFunc(func) => {
@@ -55,6 +58,8 @@ final class SeqDiffer[F[_], A](
             pairType = PairType.Both,
             isIgnored = isIgnored,
             isOk = isIgnored || allIsOk,
+            differenceCount = results.differenceCount,
+            ignoredCount = results.ignoredCount,
           )
         }
       }
@@ -68,6 +73,8 @@ final class SeqDiffer[F[_], A](
         pairType = PairType.ObtainedOnly,
         isIgnored = isIgnored,
         isOk = isIgnored,
+        differenceCount = actual.size,
+        ignoredCount = if (isIgnored) actual.size else 0,
       )
     case DiffInput.ExpectedOnly(expected) =>
       ListResult(
@@ -78,6 +85,8 @@ final class SeqDiffer[F[_], A](
         pairType = PairType.ExpectedOnly,
         isIgnored = isIgnored,
         isOk = isIgnored,
+        differenceCount = expected.size,
+        ignoredCount = if (isIgnored) expected.size else 0,
       )
   }
 

--- a/modules/core/src/main/scala/difflicious/differ/SeqDiffer.scala
+++ b/modules/core/src/main/scala/difflicious/differ/SeqDiffer.scala
@@ -3,7 +3,7 @@ package difflicious.differ
 import difflicious.DiffResult.ListResult
 import difflicious.utils.SeqLike
 import difflicious.ConfigureOp.PairBy
-import difflicious.{ConfigureError, ConfigureOp, ConfigurePath, DiffInput, DiffResult, Differ, PairType}
+import difflicious.{ConfigureError, ConfigureOp, ConfigurePath, DiffInput, DiffResult, Differ, PairType, PairingFn}
 import SeqDiffer.diffPairByFunc
 import difflicious.internal.SumCountsSyntax.DiffResultIterableOps
 import difflicious.utils.TypeName.SomeTypeName
@@ -51,7 +51,7 @@ final class SeqDiffer[F[_], A](
           )
         }
         case PairBy.ByFunc(func) => {
-          val (results, allIsOk) = diffPairByFunc(actual, expected, func, itemDiffer)
+          val (results, allIsOk) = diffPairByFunc(actual, expected, PairingFn.lift(func), itemDiffer)
           ListResult(
             typeName = typeName,
             items = results,
@@ -157,10 +157,10 @@ object SeqDiffer {
   // Given two lists of item, find "matching" items using te provided function
   // (where "matching" means ==). For example we might want to items by
   // person name.
-  private[difflicious] def diffPairByFunc[A](
+  private[difflicious] def diffPairByFunc[A, B](
     obtained: Seq[A],
     expected: Seq[A],
-    func: A => Any,
+    func: PairingFn[A, B],
     itemDiffer: Differ[A],
   ): (Vector[DiffResult], Boolean) = {
     val matchedIndexes = mutable.BitSet.empty
@@ -168,18 +168,16 @@ object SeqDiffer {
     val expWithIdx = expected.zipWithIndex
     var allIsOk = true
     obtained.foreach { a =>
-      val aMatchVal = func(a)
-      val found = expWithIdx.find {
-        case (e, idx) =>
-          if (!matchedIndexes.contains(idx) && aMatchVal == func(e)) {
-            val res = itemDiffer.diff(a, e)
-            results += res
-            matchedIndexes += idx
-            allIsOk &= res.isOk
-            true
-          } else {
-            false
-          }
+      val found = expWithIdx.find { case (e, idx) =>
+        if (!matchedIndexes.contains(idx) && func.matching(a, e)(itemDiffer)) {
+          val res = itemDiffer.diff(a, e)
+          results += res
+          matchedIndexes += idx
+          allIsOk &= res.isOk
+          true
+        } else {
+          false
+        }
       }
 
       if (found.isEmpty) {
@@ -188,12 +186,11 @@ object SeqDiffer {
       }
     }
 
-    expWithIdx.foreach {
-      case (e, idx) =>
-        if (!matchedIndexes.contains(idx)) {
-          results += itemDiffer.diff(DiffInput.ExpectedOnly(e))
-          allIsOk = false
-        }
+    expWithIdx.foreach { case (e, idx) =>
+      if (!matchedIndexes.contains(idx)) {
+        results += itemDiffer.diff(DiffInput.ExpectedOnly(e))
+        allIsOk = false
+      }
     }
 
     (results.toVector, allIsOk)

--- a/modules/core/src/main/scala/difflicious/differ/SetDiffer.scala
+++ b/modules/core/src/main/scala/difflicious/differ/SetDiffer.scala
@@ -3,9 +3,10 @@ package difflicious.differ
 import difflicious.ConfigureOp.PairBy
 import difflicious.DiffResult.ListResult
 import difflicious.differ.SeqDiffer.diffPairByFunc
+import difflicious.internal.SumCountsSyntax.DiffResultIterableOps
 import difflicious.utils.TypeName.SomeTypeName
 import difflicious.utils.SetLike
-import difflicious.{Differ, ConfigureOp, ConfigureError, ConfigurePath, DiffInput, PairType}
+import difflicious.{ConfigureError, ConfigureOp, ConfigurePath, DiffInput, Differ, PairType}
 
 final class SetDiffer[F[_], A](
   isIgnored: Boolean,
@@ -26,6 +27,8 @@ final class SetDiffer[F[_], A](
         PairType.ObtainedOnly,
         isIgnored = isIgnored,
         isOk = isIgnored,
+        differenceCount = actual.size,
+        ignoredCount = if (isIgnored) actual.size else 0,
       )
     case DiffInput.ExpectedOnly(expected) =>
       ListResult(
@@ -36,8 +39,10 @@ final class SetDiffer[F[_], A](
         pairType = PairType.ExpectedOnly,
         isIgnored = isIgnored,
         isOk = isIgnored,
+        differenceCount = expected.size,
+        ignoredCount = if (isIgnored) expected.size else 0,
       )
-    case DiffInput.Both(obtained, expected) => {
+    case DiffInput.Both(obtained, expected) =>
       val (results, overallIsSame) = diffPairByFunc(obtained.toSeq, expected.toSeq, matchFunc, itemDiffer)
       ListResult(
         typeName = typeName,
@@ -45,8 +50,9 @@ final class SetDiffer[F[_], A](
         pairType = PairType.Both,
         isIgnored = isIgnored,
         isOk = isIgnored || overallIsSame,
+        differenceCount = results.differenceCount,
+        ignoredCount = results.ignoredCount,
       )
-    }
   }
 
   override def configureIgnored(newIgnored: Boolean): Differ[F[A]] =

--- a/modules/core/src/main/scala/difflicious/differ/SetDiffer.scala
+++ b/modules/core/src/main/scala/difflicious/differ/SetDiffer.scala
@@ -6,12 +6,12 @@ import difflicious.differ.SeqDiffer.diffPairByFunc
 import difflicious.internal.SumCountsSyntax.DiffResultIterableOps
 import difflicious.utils.TypeName.SomeTypeName
 import difflicious.utils.SetLike
-import difflicious.{ConfigureError, ConfigureOp, ConfigurePath, DiffInput, Differ, PairType}
+import difflicious.{ConfigureError, ConfigureOp, ConfigurePath, DiffInput, Differ, PairType, PairingFn}
 
 final class SetDiffer[F[_], A](
   isIgnored: Boolean,
   itemDiffer: Differ[A],
-  matchFunc: A => Any,
+  matchFunc: PairingFn[A, Any],
   typeName: SomeTypeName,
   asSet: SetLike[F],
 ) extends Differ[F[A]] {
@@ -89,7 +89,7 @@ final class SetDiffer[F[_], A](
           new SetDiffer[F, A](
             isIgnored = isIgnored,
             itemDiffer = itemDiffer,
-            matchFunc = m.func.asInstanceOf[A => Any],
+            matchFunc = PairingFn.lift(m.func.asInstanceOf[A => Any]),
             typeName = typeName,
             asSet = asSet,
           ),
@@ -105,7 +105,7 @@ object SetDiffer {
   ): SetDiffer[F, A] = new SetDiffer[F, A](
     isIgnored = false,
     itemDiffer,
-    matchFunc = identity,
+    matchFunc = PairingFn.approximate(threshold = 1).asInstanceOf[PairingFn[A, Any]],
     typeName = typeName,
     asSet = asSet,
   )

--- a/modules/core/src/main/scala/difflicious/internal/SumCountsSyntax.scala
+++ b/modules/core/src/main/scala/difflicious/internal/SumCountsSyntax.scala
@@ -1,0 +1,10 @@
+package difflicious.internal
+
+import difflicious.DiffResult
+
+private[difflicious] object SumCountsSyntax {
+  implicit class DiffResultIterableOps(iterable: Iterable[DiffResult]) {
+    def differenceCount: Int = iterable.foldLeft(0) { (acc, next) => acc + next.differenceCount }
+    def ignoredCount: Int = iterable.foldLeft(0) { (acc, next) => acc + next.ignoredCount }
+  }
+}

--- a/modules/coretest/src/test/scala/difflicious/DifferSpec.scala
+++ b/modules/coretest/src/test/scala/difflicious/DifferSpec.scala
@@ -544,6 +544,54 @@ class DifferSpec extends ScalaCheckSuite with ScalaVersionDependentTests {
     )
   }
 
+  test("Set: intelligently match minimally-different entries") {
+    assertConsoleDiffOutput(
+      Differ
+        .setDiffer[Set, CC]
+        .configureRaw(ConfigurePath.of("each", "dd"), ConfigureOp.ignore)
+        .unsafeGet,
+      Set(
+        CC(1, "s1", 3),
+        CC(2, "s2", 2),
+        CC(4, "s2", 2),
+        CC(5, "s8", 2),
+      ),
+      Set(
+        CC(1, "s1", 1),
+        CC(2, "s2", 2),
+        CC(3, "s2", 2),
+        CC(3, "s3", 8),
+      ),
+      s"""Set(
+         |  CC(
+         |    i: 1,
+         |    s: "s1",
+         |    dd: $grayIgnoredStr
+         |  ),
+         |  CC(
+         |    i: 2,
+         |    s: "s2",
+         |    dd: $grayIgnoredStr
+         |  ),
+         |  CC(
+         |    i: ${R}4$X -> ${G}3$X,
+         |    s: "s2",
+         |    dd: $grayIgnoredStr
+         |  ),
+         |  ${R}CC(
+         |    i: 5,
+         |    s: "s8",
+         |    dd: $justIgnoredStr
+         |  )$X,
+         |  ${G}CC(
+         |    i: 3,
+         |    s: "s3",
+         |    dd: $justIgnoredStr
+         |  )$X
+         |)""".stripMargin,
+    )
+  }
+
   test("Set: When only 'obtained' is provided when diffing") {
     assertConsoleDiffOutput(
       Differ[List[Set[Int]]],


### PR DESCRIPTION
This tries to implement #66 in the following manner:

- Introduces difference counts (one for the number of difference, and another for the number of ignored fields)
- Abstracts pairing functions into `PairingFn` which can be equals-based or differ-based:
  - Equals-based functions work the same way as they used to 
  - Further, differ-based pairing can be either approximate, using the default item differ or can rely on a user-specified differ instance. This is to allow for customizability.
  - Differ-based pairing functions take an additional parameter for difference count threshold.
- The difference count is compared against the threshold specified in the pairing function to then match similar elements.

I made some assumptions when implementing this such as using the approximate pairing function by default and specifying difference threshold to be 1, but I am open to discussing/adjusting them as needed.