### PR TITLE
Update magnolia (Scala 2) to 1.1.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val core = projectMatrix
             Seq("com.softwaremill.magnolia1_3" %%% "magnolia" % "1.3.20")
           } else
             Seq(
-              "com.softwaremill.magnolia1_2" %%% "magnolia" % "1.1.10",
+              "com.softwaremill.magnolia1_2" %%% "magnolia" % "1.1.13",
               "org.scala-lang" % "scala-reflect" % Build.Scala213,
             )),
     Compile / sourceGenerators += Def.task {


### PR DESCRIPTION
## What

Bumps `com.softwaremill.magnolia1_2:magnolia` from `1.1.10` → `1.1.13` for the Scala 2 build.

## Why

`magnolia1_3` (Scala 3) was already bumped to `1.3.20` in #183, but `magnolia1_2` (Scala 2) is still pinned to `1.1.10`. Downstream consumers that pull in a newer magnolia transitively (e.g. via `tapir-core` 1.13.x, which now requires `magnolia1_2:magnolia` 1.1.13) end up with a conflicting resolution where the runtime magnolia is 1.1.13 but the difflicious-core jar was compiled against 1.1.10. The result is silent failure of `Differ.derived` / `AutoDerivation` at the consumer's compile time:

```
could not find implicit value for evidence parameter of type difflicious.Differ[<some product or sealed type>]
```

Bumping difflicious to compile against magnolia 1.1.13 would resolve this for downstream users.

## Status: not green — this is a reproducer, not a fix

A clean version bump breaks difflicious's own coretest suite:

```
[error] modules/coretest/src/test/scala/difflicious/testtypes.scala:75:57: type mismatch;
[error]  found   : magnolia1.ReadOnlyCaseClass[parameters$macro$14.Typeclass,difflicious.testtypes.Sealed.Sub3]
[error]  required: magnolia1.ReadOnlyCaseClass[difflicious.Differ,?]
[error]     implicit val differ: Differ[Sealed] = Differ.derived[Sealed]
```

## Root cause

magnolia [PR #628](https://github.com/softwaremill/magnolia/pull/628) (Support covariant typeclass families in Scala 2), landed in 1.1.11, changed how the macro generates the `join`/`split` call:

Before:
```scala
${c.prefix}.join(new CaseClass[Differ, T](...))
```

After:
```scala
${c.prefix}.join(new CaseClass[paramsVal.Typeclass, T](...))
```

`paramsVal` is a `magnolia1.Parts[F, Tc]` where `Tc[_] <: TcWide[_]` (the wide typeclass — `Differ` in our case). The bound is on `Parts.PartiallyApplied.apply`, but **not** on the `Parts` class itself, so once a `Parts` value exists, the typer no longer sees `Tc <: Differ`. Combined with covariance of `+Typeclass[_]` on `ReadOnlyCaseClass`, this means the typer can't fit `ReadOnlyCaseClass[paramsVal.Typeclass, T]` into the `ReadOnlyCaseClass[Differ, T]` parameter of `join`.

This is acknowledged upstream:

- [softwaremill/magnolia#627](https://github.com/softwaremill/magnolia/issues/627) (original issue)
- [softwaremill/magnolia#637](https://github.com/softwaremill/magnolia/pull/637) — "Add genNarrow": _"It's difficult to narrow recursive instances, especially in Scala 2 where we don't constrain `join` and `split` signatures."_

For typeclasses that don't actually need narrowing (`type Typeclass[T] = Differ[T]` is invariant — no covariant `Out` parameter like `magnolia1.examples.Show[Out, T]`), the new behaviour is a regression.

## Things I tried that didn't work

1. **Swap concrete `Differ` for `Typeclass` alias in `join` / `split` / `SealedTraitDiffer` signatures.** Still fails — `parameters$macro$14.Typeclass` doesn't unify with `Differ.Typeclass` (path-dependent aliases don't reduce against each other even when both target the same concrete type).
2. **Higher-kinded type parameter with subtype bound: `def join[Tc[X] <: Differ[X], T](ctx: ReadOnlyCaseClass[Tc, T]): Differ[T]`.** Different error — Scala refuses the bound:
   ```
   inferred type arguments [[a]parameters$macro$14.Typeclass[a], Sealed.Sub3] do not conform
   to method join's type parameter bounds [Tc[X] <: Differ[X], T]
   ```
   Because `Parts[F, Tc]` erases the `Tc <: TcWide` constraint, the typer can't verify the bound.

## Possible paths forward

- **Wait for [#637](https://github.com/softwaremill/magnolia/pull/637) (`genNarrow`) to merge in magnolia.** Then `Differ.derived` could call `Magnolia.genNarrow[Differ, T]` to opt out of narrowing entirely. Cleanest answer if it lands.
- **File a magnolia issue** asking for the `Tc <: TcWide` bound to be preserved on the `Parts` class itself (declare `class Parts[F[+_[_]], +Tc[_] <: TcWide[_], TcWide[_]]` or similar). This would unblock the simple non-narrowing case without anyone needing to opt in.
- **Pin magnolia1_2 to 1.1.10 in difflicious's published artifact metadata** as a hard upper bound, so downstreams using newer magnolia get a resolution conflict at build time (instead of silent runtime breakage). Less invasive but pushes the problem downstream.

## Reproducer for downstream consumers

Any project that combines tapir 1.13.x with difflicious 0.5.1 hits this — tapir 1.13.x pulls `magnolia1_2:magnolia` 1.1.13 transitively, which is the runtime magnolia, but difflicious-core was compiled against 1.1.10. Tests that extend an `AutoDerivation`-based `assertEquals` helper fail to compile with a `could not find implicit value for evidence parameter of type difflicious.Differ[...]` for any product/sealed type whose derivation requires recursion.

Leaving this PR as **draft** since it's a reproducer, not a ready-to-merge fix. Happy to help land whichever path the maintainers prefer.

