### PR TITLE
Add OneOfDiffer and use it for sealed trait derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ metals.sbt
 TempGo.scala
 metals.sbt
 .bloop
+/wt

--- a/modules/core/src/main/scala-2.13/difflicious/DifferGen.scala
+++ b/modules/core/src/main/scala-2.13/difflicious/DifferGen.scala
@@ -1,11 +1,8 @@
 package difflicious
-import difflicious.DiffResult.MismatchTypeResult
-import difflicious.differ.RecordDiffer
-import difflicious.internal.EitherGetSyntax.*
+import difflicious.differ.{OneOfDiffer, RecordDiffer}
 import difflicious.utils.TypeName.SomeTypeName
 import magnolia1.*
 
-import scala.collection.mutable
 import scala.collection.immutable.ListMap
 
 trait DifferGen {
@@ -24,113 +21,21 @@ trait DifferGen {
     )
   }
 
-  final class SealedTraitDiffer[T](ctx: SealedTrait[Differ, T], isIgnored: Boolean) extends Differ[T] {
-    // $COVERAGE-OFF$
-    require(
-      {
-        val allShortNames = ctx.subtypes.map(_.typeName.short)
-        allShortNames.toSet.size == allShortNames.size
-      },
-      "Currently all subclass names across the whole sealed trait hierarchy must be distinct for simplicity of the configure API. " +
-        "Please raise an issue if you need subclasses with the same names",
-    )
-    // $COVERAGE-ON$
-
-    override type R = DiffResult
-
-    override def diff(inputs: DiffInput[T]): DiffResult = inputs match {
-      case DiffInput.ObtainedOnly(obtained) =>
-        ctx.split(obtained)(sub => sub.typeclass.diff(DiffInput.ObtainedOnly(sub.cast(obtained))))
-      case DiffInput.ExpectedOnly(expected) =>
-        ctx.split(expected)(sub => sub.typeclass.diff(DiffInput.ExpectedOnly(sub.cast(expected))))
-      case DiffInput.Both(obtained, expected) => {
-        ctx.split(obtained) { obtainedSubtype =>
-          ctx.split(expected) { expectedSubtype =>
-            if (obtainedSubtype.typeName.short == expectedSubtype.typeName.short) {
-              obtainedSubtype.typeclass
-                .diff(
-                  obtainedSubtype.cast(obtained),
-                  expectedSubtype.cast(expected).asInstanceOf[obtainedSubtype.SType],
-                )
-            } else {
-              MismatchTypeResult(
-                obtained = obtainedSubtype.typeclass.diff(DiffInput.ObtainedOnly(obtainedSubtype.cast(obtained))),
-                obtainedTypeName = toDiffliciousTypeName(obtainedSubtype.typeName),
-                expected = expectedSubtype.typeclass.diff(DiffInput.ExpectedOnly(expectedSubtype.cast(expected))),
-                expectedTypeName = toDiffliciousTypeName(expectedSubtype.typeName),
-                pairType = PairType.Both,
-                isIgnored = isIgnored,
-              )
-            }
-          }
-        }
-      }
-    }
-
-    override def configureIgnored(newIgnored: Boolean): Typeclass[T] = {
-      val newSubTypes = mutable.ArrayBuffer.empty[Subtype[Differ, T]]
-      ctx.subtypes.foreach { sub =>
-        newSubTypes += Subtype(
-          name = sub.typeName,
-          idx = sub.index,
-          anns = sub.annotationsArray,
-          tpeAnns = sub.typeAnnotationsArray,
-          tc =
-            CallByNeed(sub.typeclass.configureRaw(ConfigurePath.current, ConfigureOp.SetIgnored(newIgnored)).unsafeGet),
-          isType = sub.cast.isDefinedAt,
-          asType = sub.cast.apply,
-        )
-      }
-      val newSealedTrait = new SealedTrait(
-        typeName = ctx.typeName,
-        subtypesArray = newSubTypes.toArray,
-        annotationsArray = ctx.annotations.toArray,
-        typeAnnotationsArray = ctx.typeAnnotations.toArray,
-      )
-      new SealedTraitDiffer[T](newSealedTrait, isIgnored = newIgnored)
-    }
-
-    override def configurePath(
-      step: String,
-      nextPath: ConfigurePath,
-      op: ConfigureOp,
-    ): Either[ConfigureError, Typeclass[T]] =
-      ctx.subtypes.zipWithIndex.find { case (sub, _) => sub.typeName.short == step } match {
-        case Some((sub, idx)) =>
-          sub.typeclass
-            .configureRaw(nextPath, op)
-            .map { newDiffer =>
-              Subtype(
-                name = sub.typeName,
-                idx = sub.index,
-                anns = sub.annotationsArray,
-                tpeAnns = sub.typeAnnotationsArray,
-                tc = CallByNeed(newDiffer),
-                isType = sub.cast.isDefinedAt,
-                asType = sub.cast.apply,
-              )
-            }
-            .map { newSubType =>
-              val newSubTypes = ctx.subtypes.updated(idx, newSubType)
-              val newSealedTrait = new SealedTrait(
-                typeName = ctx.typeName,
-                subtypesArray = newSubTypes.toArray,
-                annotationsArray = ctx.annotations.toArray,
-                typeAnnotationsArray = ctx.typeAnnotations.toArray,
-              )
-              new SealedTraitDiffer[T](newSealedTrait, isIgnored)
-            }
-        case None =>
-          Left(ConfigureError.UnrecognizedSubType(nextPath, ctx.subtypes.map(_.typeName.short).toVector))
-      }
-
-    override def configurePairBy(path: ConfigurePath, op: ConfigureOp.PairBy[?]): Either[ConfigureError, Typeclass[T]] =
-      Left(ConfigureError.InvalidConfigureOp(path, op, "SealedTraitDiffer"))
-
-  }
-
   def split[T](ctx: SealedTrait[Differ, T]): Differ[T] =
-    new SealedTraitDiffer[T](ctx, isIgnored = false)
+    new OneOfDiffer[T](
+      cases = ctx.subtypes.map { sub =>
+        val extract: T => Option[Any] = value =>
+          if (sub.cast.isDefinedAt(value)) Some(sub.cast(value))
+          else None
+        OneOfDiffer.Case[T, Any](
+          typeName = toDiffliciousTypeName(sub.typeName),
+          extract = extract,
+          differ = sub.typeclass.asInstanceOf[Differ[Any]],
+        )
+      }.toVector,
+      isIgnored = false,
+      differTypeName = "OneOfDiffer",
+    )
 
   def derived[T]: Differ[T] = macro Magnolia.gen[T]
 

--- a/modules/core/src/main/scala-3/difflicious/DifferGen.scala
+++ b/modules/core/src/main/scala-3/difflicious/DifferGen.scala
@@ -1,14 +1,10 @@
 package difflicious
-import difflicious.DiffResult.MismatchTypeResult
-import difflicious.differ.RecordDiffer
+import difflicious.differ.{OneOfDiffer, RecordDiffer}
 import difflicious.utils.TypeName
 import difflicious.utils.TypeName.SomeTypeName
-import difflicious.internal.EitherGetSyntax.*
 
 import scala.collection.immutable.ListMap
 import magnolia1.*
-
-import scala.collection.mutable
 
 trait DifferGen extends Derivation[Differ]:
   override def join[T](ctx: CaseClass[Differ, T]): Differ[T] =
@@ -24,99 +20,20 @@ trait DifferGen extends Derivation[Differ]:
     )
 
   override def split[T](ctx: SealedTrait[Differ, T]): Differ[T] =
-    new SealedTraitDiffer(ctx, isIgnored = false)
-
-  final class SealedTraitDiffer[T](ctx: SealedTrait[Differ, T], isIgnored: Boolean) extends Differ[T]:
-    override type R = DiffResult
-
-    override def diff(inputs: DiffInput[T]): DiffResult = inputs match
-      case DiffInput.ObtainedOnly(obtained) =>
-        ctx.choose(obtained)(sub => sub.typeclass.diff(DiffInput.ObtainedOnly(sub.cast(obtained))))
-      case DiffInput.ExpectedOnly(expected) =>
-        ctx.choose(expected)(sub => sub.typeclass.diff(DiffInput.ExpectedOnly(sub.cast(expected))))
-      case DiffInput.Both(obtained, expected) =>
-        ctx.choose(obtained) { obtainedSubtype =>
-          ctx.choose(expected) { expectedSubtype =>
-            if obtainedSubtype.typeInfo.short == expectedSubtype.typeInfo.short then
-              obtainedSubtype.typeclass.asInstanceOf[Differ[T]].diff(obtainedSubtype.value, expectedSubtype.value)
-            else
-              MismatchTypeResult(
-                obtained = obtainedSubtype.typeclass.diff(DiffInput.ObtainedOnly(obtainedSubtype.cast(obtained))),
-                obtainedTypeName = toDiffliciousTypeName(obtainedSubtype.typeInfo),
-                expected = expectedSubtype.typeclass.diff(DiffInput.ExpectedOnly(expectedSubtype.cast(expected))),
-                expectedTypeName = toDiffliciousTypeName(expectedSubtype.typeInfo),
-                pairType = PairType.Both,
-                isIgnored = isIgnored,
-              )
-          }
-        }
-
-    override def configureIgnored(newIgnored: Boolean): Differ[T] =
-      val newSubtypes = mutable.ArrayBuffer.empty[SealedTrait.Subtype[Differ, T, Any]]
-      ctx.subtypes.foreach { sub =>
-        newSubtypes += SealedTrait.Subtype[Differ, T, Any](
-          typeInfo = sub.typeInfo,
-          annotations = sub.annotations,
-          typeAnnotations = sub.typeAnnotations,
-          isObject = sub.isObject,
-          index = sub.index,
-          callByNeed = CallByNeed(
-            sub.typeclass
-              .configureRaw(ConfigurePath.current, ConfigureOp.SetIgnored(newIgnored))
-              .unsafeGet
-              .asInstanceOf[Differ[Any]],
-          ),
-          isType = sub.cast.isDefinedAt,
-          asType = sub.cast.apply,
+    new OneOfDiffer[T](
+      cases = ctx.subtypes.iterator.map { sub =>
+        val extract: T => Option[Any] = value =>
+          if sub.cast.isDefinedAt(value) then Some(sub.cast(value))
+          else None
+        OneOfDiffer.Case[T, Any](
+          typeName = toDiffliciousTypeName(sub.typeInfo),
+          extract = extract,
+          differ = sub.typeclass.asInstanceOf[Differ[Any]],
         )
-      }
-      val newSealedTrait = new SealedTrait(
-        typeInfo = ctx.typeInfo,
-        subtypes = IArray(newSubtypes.toArray: _*),
-        annotations = ctx.annotations,
-        typeAnnotations = ctx.typeAnnotations,
-        isEnum = ctx.isEnum,
-      )
-      new SealedTraitDiffer[T](newSealedTrait, isIgnored = newIgnored)
-
-    protected def configurePath(
-      step: String,
-      nextPath: ConfigurePath,
-      op: ConfigureOp,
-    ): Either[ConfigureError, Differ[T]] =
-      ctx.subtypes.zipWithIndex.find { (sub, _) => sub.typeInfo.short == step } match {
-        case Some((sub, idx)) =>
-          sub.typeclass
-            .configureRaw(nextPath, op)
-            .map { newDiffer =>
-              val newSubtype = SealedTrait.Subtype[Differ, T, Any](
-                typeInfo = sub.typeInfo,
-                annotations = sub.annotations,
-                typeAnnotations = sub.typeAnnotations,
-                isObject = sub.isObject,
-                index = sub.index,
-                callByNeed = CallByNeed(newDiffer.asInstanceOf[Differ[Any]]),
-                isType = sub.cast.isDefinedAt,
-                asType = sub.cast.apply,
-              )
-              val newSubtypes = ctx.subtypes.updated(idx, newSubtype)
-              val newSealedTrait = new SealedTrait(
-                typeInfo = ctx.typeInfo,
-                subtypes = newSubtypes,
-                annotations = ctx.annotations,
-                typeAnnotations = ctx.typeAnnotations,
-                isEnum = ctx.isEnum,
-              )
-              new SealedTraitDiffer[T](newSealedTrait, isIgnored)
-            }
-        case None =>
-          Left(ConfigureError.UnrecognizedSubType(nextPath, ctx.subtypes.map(_.typeInfo.short).toVector))
-      }
-
-    protected def configurePairBy(path: ConfigurePath, op: ConfigureOp.PairBy[?]): Either[ConfigureError, Differ[T]] =
-      Left(ConfigureError.InvalidConfigureOp(path, op, "SealedTraitDiffer"))
-
-  end SealedTraitDiffer
+      }.toVector,
+      isIgnored = false,
+      differTypeName = "OneOfDiffer",
+    )
 
   private def toDiffliciousTypeName(typeInfo: TypeInfo): SomeTypeName = {
     TypeName(

--- a/modules/core/src/main/scala/difflicious/Differ.scala
+++ b/modules/core/src/main/scala/difflicious/Differ.scala
@@ -53,6 +53,9 @@ object Differ extends DifferTupleInstances with DifferGen with DifferPlatform wi
 
   def apply[A](implicit differ: Differ[A]): Differ[A] = differ
 
+  def oneOf[A](case0: OneOfDiffer.Case[A, ?], otherCases: OneOfDiffer.Case[A, ?]*): OneOfDiffer[A] =
+    new OneOfDiffer[A]((case0 +: otherCases).toVector, isIgnored = false, differTypeName = "OneOfDiffer")
+
   def useEquals[T](valueToString: T => String): EqualsDiffer[T] =
     new EqualsDiffer[T](isIgnored = false, valueToString = valueToString)
 

--- a/modules/core/src/main/scala/difflicious/differ/OneOfDiffer.scala
+++ b/modules/core/src/main/scala/difflicious/differ/OneOfDiffer.scala
@@ -1,0 +1,128 @@
+package difflicious.differ
+
+import difflicious.*
+import difflicious.DiffResult.MismatchTypeResult
+import difflicious.utils.TypeName.SomeTypeName
+
+final class OneOfDiffer[A](
+  cases: Vector[OneOfDiffer.Case[A, ?]],
+  isIgnored: Boolean,
+  differTypeName: String,
+) extends Differ[A] {
+  import OneOfDiffer.*
+
+  private val caseIds = cases.map(_.id)
+  require(cases.nonEmpty, "OneOfDiffer requires at least one case")
+  require(
+    caseIds.distinct.size == caseIds.size,
+    s"OneOfDiffer case ids must be distinct. Found case ids: ${caseIds.mkString(",")}",
+  )
+
+  override type R = DiffResult
+
+  override def diff(inputs: DiffInput[A]): DiffResult = inputs match {
+    case DiffInput.ObtainedOnly(obtained) =>
+      val obtainedCase = selectCaseForValue(obtained)
+      applyCaseToDiffInput(obtainedCase, DiffInput.ObtainedOnly(obtained))
+    case DiffInput.ExpectedOnly(expected) =>
+      val expectedCase = selectCaseForValue(expected)
+      applyCaseToDiffInput(expectedCase, DiffInput.ExpectedOnly(expected))
+    case DiffInput.Both(obtained, expected) =>
+      val obtainedCase = selectCaseForValue(obtained)
+      val expectedCase = selectCaseForValue(expected)
+      if (obtainedCase.id == expectedCase.id) {
+        applyCaseToDiffInput(obtainedCase, DiffInput.Both(obtained, expected))
+      } else {
+        MismatchTypeResult(
+          obtained = applyCaseToDiffInput(obtainedCase, DiffInput.ObtainedOnly(obtained)),
+          obtainedTypeName = obtainedCase.typeName,
+          expected = applyCaseToDiffInput(expectedCase, DiffInput.ExpectedOnly(expected)),
+          expectedTypeName = expectedCase.typeName,
+          pairType = PairType.Both,
+          isIgnored = isIgnored,
+        )
+      }
+  }
+
+  override def configureIgnored(newIgnored: Boolean): Differ[A] =
+    new OneOfDiffer[A](
+      cases = cases.map(_.configureRawOrThrow(ConfigurePath.current, ConfigureOp.SetIgnored(newIgnored))),
+      isIgnored = newIgnored,
+      differTypeName = differTypeName,
+    )
+
+  override def configurePath(
+    step: String,
+    nextPath: ConfigurePath,
+    op: ConfigureOp,
+  ): Either[ConfigureError, Differ[A]] = {
+    cases.zipWithIndex.find { case (caseDef, _) => caseDef.id == step } match {
+      case Some((caseDef, idx)) =>
+        caseDef.configureRaw(nextPath, op).map { updatedCase =>
+          new OneOfDiffer[A](
+            cases = cases.updated(idx, updatedCase),
+            isIgnored = isIgnored,
+            differTypeName = differTypeName,
+          )
+        }
+      case None =>
+        Left(ConfigureError.UnrecognizedSubType(nextPath, caseIds))
+    }
+  }
+
+  override def configurePairBy(path: ConfigurePath, op: ConfigureOp.PairBy[?]): Either[ConfigureError, Differ[A]] =
+    Left(ConfigureError.InvalidConfigureOp(path, op, differTypeName))
+
+  private def selectCaseForValue(value: A): Case[A, ?] =
+    cases.iterator
+      .find(_.extract(value).isDefined)
+      .getOrElse {
+        throw new IllegalStateException(
+          s"OneOfDiffer could not match value to any configured case. Configured cases: ${caseIds.mkString(",")}",
+        )
+      }
+
+  private def applyCaseToDiffInput(caseDef: Case[A, ?], inputs: DiffInput[A]): DiffResult =
+    caseDef.differ.asInstanceOf[Differ[Any]].diff(inputs.map(_.asInstanceOf[Any]))
+}
+
+object OneOfDiffer {
+
+  /** A single possible case in a OneOfDiffer.
+    *
+    * A typeName is required because we want to provide an alternative name. For example, a JSON array may be
+    * stored/compared as a List, but we want to call it JsonArray
+    */
+  final case class Case[A, B](
+    typeName: SomeTypeName,
+    extract: A => Option[B],
+    differ: Differ[B],
+  ) {
+    def id: String = typeName.short
+
+    private[difflicious] def configureRaw(
+      path: ConfigurePath,
+      op: ConfigureOp,
+    ): Either[ConfigureError, Case[A, B]] =
+      differ.configureRaw(path, op).map { updatedDiffer =>
+        copy(differ = updatedDiffer)
+      }
+
+    private[difflicious] def configureRawOrThrow(path: ConfigurePath, op: ConfigureOp): Case[A, B] =
+      configureRaw(path, op) match {
+        case Right(updatedCase) => updatedCase
+        case Left(error) => throw error
+      }
+  }
+
+  def caseOf[A, B](
+    typeName: SomeTypeName,
+    extract: A => Option[B],
+    differ: Differ[B],
+  ): Case[A, B] =
+    Case(
+      typeName = typeName,
+      extract = extract,
+      differ = differ,
+    )
+}

--- a/modules/core/src/main/scalanative/difflicious/DifferTimeInstances.scala
+++ b/modules/core/src/main/scalanative/difflicious/DifferTimeInstances.scala
@@ -1,4 +1,3 @@
 package difflicious
 
-trait DifferTimeInstancesPlatform {
-}
+trait DifferTimeInstancesPlatform {}

--- a/modules/coretest/src/test/scala/difflicious/DifferSpec.scala
+++ b/modules/coretest/src/test/scala/difflicious/DifferSpec.scala
@@ -709,6 +709,49 @@ class DifferSpec extends ScalaCheckSuite with ScalaVersionDependentTests {
     )
   }
 
+  test("OneOfDiffer: supports custom alternatives selected by extractors") {
+    final case class CustomOneOf(raw: String)
+
+    val differ = Differ.oneOf[CustomOneOf](
+      difflicious.differ.OneOfDiffer.caseOf[CustomOneOf, CustomOneOf](
+        typeName = difflicious.utils.TypeName[Any](
+          long = "difflicious.CustomOneOf.IntValue",
+          short = "IntValue",
+          typeArguments = Nil,
+        ),
+        extract = value => value.raw.toIntOption.map(_ => value),
+        differ = Differ.intDiffer.contramap[CustomOneOf](_.raw.toInt),
+      ),
+      difflicious.differ.OneOfDiffer.caseOf[CustomOneOf, CustomOneOf](
+        typeName = difflicious.utils.TypeName[Any](
+          long = "difflicious.CustomOneOf.StringValue",
+          short = "StringValue",
+          typeArguments = Nil,
+        ),
+        extract = Some(_),
+        differ = Differ.stringDiffer.contramap[CustomOneOf](_.raw),
+      ),
+    )
+
+    assertConsoleDiffOutput(
+      differ,
+      CustomOneOf("1"),
+      CustomOneOf("abc"),
+      s"""${R}IntValue$X != ${G}StringValue${X}
+         |${R}=== Obtained ===
+         |1$X
+         |${G}=== Expected ===
+         |"abc"$X""".stripMargin,
+    )
+
+    assertConsoleDiffOutput(
+      differ.configureRaw(ConfigurePath.of("IntValue"), ConfigureOp.ignore).unsafeGet,
+      CustomOneOf("1"),
+      CustomOneOf("2"),
+      grayIgnoredStr,
+    )
+  }
+
   test("Sealed trait: should display obtained and expected types when mismatch") {
     assertConsoleDiffOutput(
       Sealed.differ,
@@ -877,7 +920,7 @@ class DifferSpec extends ScalaCheckSuite with ScalaVersionDependentTests {
         ConfigureError.InvalidConfigureOp(
           ConfigurePath.current,
           ConfigureOp.PairBy.Index,
-          "SealedTraitDiffer",
+          "OneOfDiffer",
         ),
       ),
     )


### PR DESCRIPTION
Introduce a more generic OneOfDiffer for tagged/one-of style comparisons and expose it via Differ.oneOf.

The previous SealedTraitDiffer has its internals quite tied to magnolia, so this is a good step towards eventual magnolia removal.

OneOfDiffer will also allow us to support:
- Scala 3 union types
- "One of"-like data which we may not have access to underlying AST (e.g. circe JSON)