### PR TITLE
Update Scalafmt and dependency automation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,22 +1,7 @@
-merge_queue:
-  queue_controls_comment: false
-
-queue_rules:
-  - name: default
-    merge_conditions:
-      - check-success ~= ^Build and Test.*$
-
 pull_request_rules:
-  - name: queue PRs marked for merge
-    conditions:
-      - label = merge-on-build-success
-    actions:
-      queue:
-        name: default
-
-  - name: auto-queue Scala Steward PRs
+  - name: merge Scala Steward PRs
     conditions:
       - author = scala-steward
+      - status-success ~= ^Build and Test.*$
     actions:
-      queue:
-        name: default
+      merge: {}

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.ignore = [
+  { groupId = "org.scalameta", artifactId = "scalafmt-core" }
+]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version="3.11.1"
+version="3.11.4"
 maxColumn = 120
 trailingCommas = always
 continuationIndent.defnSite = 2


### PR DESCRIPTION
## Summary

- update Scalafmt from 3.11.1 to 3.11.4
- configure Scala Steward to ignore Scalafmt updates
- replace Mergify merge-queue and label rules with direct auto-merge for Scala Steward PRs after matching `Build and Test` statuses succeed

## Validation

- `sbt --client scalafmtCheckAll`
- parsed `.mergify.yml` with `yq`
- `git diff --check`