### PR TITLE
Scalatest - set DifferenceFoundException as cause

### DIFF
--- a/modules/core/src/main/scala/difflicious/DifferDerivationMacrosCommon.scala
+++ b/modules/core/src/main/scala/difflicious/DifferDerivationMacrosCommon.scala
@@ -67,6 +67,7 @@ private[difflicious] trait DifferDerivationMacrosCommon { this: hearth.MacroComm
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = scala.concurrent.duration.FiniteDuration(10, java.util.concurrent.TimeUnit.SECONDS),
       ) { (errorLogs, errors) =>
         formatDerivationErrors[T](errorLogs, errors.toVector)
       }

--- a/modules/scalatest/src/main/scala/difflicious/scalatest/ScalatestDifferenceFoundException.scala
+++ b/modules/scalatest/src/main/scala/difflicious/scalatest/ScalatestDifferenceFoundException.scala
@@ -1,7 +1,7 @@
 package difflicious.scalatest
 
 import difflicious.DiffResult
-import difflicious.reporter.{DifferenceFound, UlidGenerator}
+import difflicious.reporter.{DifferenceFound, DifferenceFoundException, UlidGenerator}
 import org.scalactic.source.Position
 import org.scalatest.exceptions.{StackDepthException, TestFailedException}
 
@@ -11,7 +11,15 @@ final class ScalatestDifferenceFoundException(
 )(implicit pos: Position)
     extends TestFailedException(
       (_: StackDepthException) => Some(DifferenceFound.message(testId, diffResult)),
-      None,
+      Some(
+        DifferenceFoundException(
+          diffResult = diffResult,
+          fileName = pos.fileName,
+          filePath = pos.filePathname,
+          lineNumber = pos.lineNumber,
+          testId = testId,
+        ),
+      ),
       pos,
       None,
     )

--- a/modules/scalatest/src/test/scalajvm/difflicious/scalatest/DiffResultJsonlReporterSpec.scala
+++ b/modules/scalatest/src/test/scalajvm/difflicious/scalatest/DiffResultJsonlReporterSpec.scala
@@ -4,13 +4,14 @@ import difflicious.DiffResult
 import difflicious.DiffResult.ValueResult
 import difflicious.reporter.DiffResultJsonlWriter
 import difflicious.reporter.DiffliciousResultDefaults
+import difflicious.reporter.DifferenceFound
 import difflicious.reporter.Ulid
 import difflicious.utils.TypeName
 import io.circe.Json
 import io.circe.parser.parse
 import munit.FunSuite
 import org.scalactic.source.Position
-import org.scalatest.Args
+import org.scalatest.{Args, Inside}
 import org.scalatest.events.{NameInfo, Ordinal, ScopeOpened, TestFailed}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.funsuite.AnyFunSuite
@@ -41,7 +42,7 @@ class DiffResultJsonlReporterSpec extends FunSuite {
     assertEquals(failure.fileName, "ExampleSuite.scala")
     assertEquals(failure.filePath, "/workspace/ExampleSuite.scala")
     assertEquals(failure.lineNumber, 37)
-    assertEquals(failure.getCause, null)
+    assert(failure.getCause.isInstanceOf[DifferenceFound])
     assertEquals(failure.payload, None)
   }
 
@@ -89,6 +90,22 @@ class DiffResultJsonlReporterSpec extends FunSuite {
           |}""".stripMargin,
       ),
     )
+  }
+
+  test("captures diff assertion failures wrapped by ScalaTest inside") {
+    val outputDir = Files.createTempDirectory("difflicious-scalatest-inside-jsonl")
+    val suite = new InsideDiffSuite(TestId)
+    val status = suite.run(None, Args(zeroRunReporter(outputDir)))
+
+    status.waitUntilCompleted()
+    assert(!status.succeeds())
+
+    val outputFiles = listJsonlFiles(outputDir)
+    assertEquals(outputFiles.size, 1)
+
+    val lines = Files.readAllLines(outputFiles.head, StandardCharsets.UTF_8)
+    assertEquals(lines.size, 1)
+    assertEquals(parseJson(lines.get(0)).hcursor.get[String]("testId"), Right(TestId))
   }
 
   test("captures nested ScalaTest scopes in hierarchy") {
@@ -287,6 +304,18 @@ class DiffResultJsonlReporterSpec extends FunSuite {
 
           ScalatestDiffAssertions.failWithDiffResult(result, testId)
         }
+      }
+    }
+  }
+
+  private final class InsideDiffSuite(testId: String) extends AnyFunSuite {
+    test("testInsideDiffFailure") {
+      Inside.inside(Some("value")) { case Some(_) =>
+        val result =
+          ValueResult.Both(intTypeName, "obtained", "expected", isSame = false, isIgnored = false)
+        implicit val pos: Position = Position("InsideDiffSuite.scala", "/workspace/InsideDiffSuite.scala", 52)
+
+        ScalatestDiffAssertions.failWithDiffResult(result, testId)
       }
     }
   }


### PR DESCRIPTION
This fixes when test failure happens in scalatest "inside"