### PR TITLE
Update docs and release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "$GITHUB_REF_NAME" dist/* --clobber
 
+      - name: Classify release tag
+        id: release-tag
+        run: |
+          if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "official=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "official=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish docs
+        if: steps.release-tag.outputs.official == 'true'
         env:
           GIT_USER_NAME: github-actions[bot]
           CURRENT_BRANCH: ${{ github.ref_name }}

--- a/build.sbt
+++ b/build.sbt
@@ -600,9 +600,21 @@ ThisBuild / githubWorkflowPublish := Seq(
     name = Some("Attach native executables to GitHub release"),
     env = Map("GH_TOKEN" -> "${{ github.token }}"),
   ),
+  WorkflowStep.Run(
+    List(
+      """if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then""",
+      "  echo \"official=true\" >> \"$GITHUB_OUTPUT\"",
+      "else",
+      "  echo \"official=false\" >> \"$GITHUB_OUTPUT\"",
+      "fi",
+    ),
+    name = Some("Classify release tag"),
+    id = Some("release-tag"),
+  ),
   WorkflowStep.Sbt(
     List("docs/docusaurusPublishGhpages"),
     name = Some("Publish docs"),
+    cond = Some("steps.release-tag.outputs.official == 'true'"),
     env = Map(
       "CURRENT_BRANCH" -> "${{ github.ref_name }}",
       "GIT_PASS" -> "${{ secrets.GITHUB_TOKEN }}",

--- a/docs/docs/CLI.md
+++ b/docs/docs/CLI.md
@@ -15,6 +15,16 @@ For non-interactive use cases such as for LLM AIs, you can view the diffs in **p
 If you are using Difflicious' [`sbt-difflicious` plugin](SbtPlugin.md), 
 running `diffliciousViewer` command will launch the TUI / CLI.
 
+## About test diff reports
+
+With the SBT plugin loaded and configured for your test framework, each failing diff test will generate a test report
+as a [JSONL](https://jsonlines.org/) file.
+
+`runId`: Whenever you run `test`, `testOnly` etc in SBT, a new test `runId` will be generated and passed to the test framework.
+The `runId` is a [ULID](https://github.com/ulid/spec) value that uniquely identifies each test run and has a timestamp embedded in it.
+
+`testId`: Each test failure will generate a unique `testId`. You can use `testId` to jump straight to the diff result for that failed test.
+
 ## Interactive TUI
 
 By default, the CLI launches in TUI (Terminal User Interface) mode. You can search for tests and interactively explore the differences.

--- a/modules/reporter-core/src/main/scala/difflicious/reporter/DiffResultTestDetails.scala
+++ b/modules/reporter-core/src/main/scala/difflicious/reporter/DiffResultTestDetails.scala
@@ -1,10 +1,7 @@
 package difflicious.reporter
 
 import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, readFromString}
-import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
 import difflicious.DiffResult
-
-import scala.annotation.nowarn
 
 /** Information regarding a diff test failure, such as the name of the test suite and test. The data in this case class
   * are serialized by the reporter
@@ -28,15 +25,6 @@ object DiffResultTestDetails {
   def fromJsonString(json: String): DiffResultTestDetails =
     readFromString(json)
 
-  @nowarn("msg=match may not be exhaustive")
-  implicit lazy val jsonValueCodec: JsonValueCodec[DiffResultTestDetails] = {
-    implicit val diffResultJsonValueCodec: JsonValueCodec[DiffResult] =
-      DiffResultJson.diffResultJsonValueCodec
-
-    JsonCodecMaker.make[DiffResultTestDetails](
-      CodecMakerConfig
-        .withTransientNone(false)
-        .withTransientDefault(false),
-    )
-  }
+  implicit lazy val jsonValueCodec: JsonValueCodec[DiffResultTestDetails] =
+    DiffResultTestDetailsJson.jsonValueCodec
 }

--- a/modules/reporter-core/src/main/scala/difflicious/reporter/DiffResultTestDetailsJson.scala
+++ b/modules/reporter-core/src/main/scala/difflicious/reporter/DiffResultTestDetailsJson.scala
@@ -1,0 +1,23 @@
+package difflicious.reporter
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
+import difflicious.DiffResult
+
+import scala.annotation.nowarn
+
+// Keep the configured macro call separate from the model companion to avoid intermittent Scala 2 compiler failures.
+// See https://github.com/plokhotnyuk/jsoniter-scala/blob/master/README.md#known-issues (item 2).
+private[reporter] object DiffResultTestDetailsJson {
+  @nowarn("msg=match may not be exhaustive")
+  implicit lazy val jsonValueCodec: JsonValueCodec[DiffResultTestDetails] = {
+    implicit val diffResultJsonValueCodec: JsonValueCodec[DiffResult] =
+      DiffResultJson.diffResultJsonValueCodec
+
+    JsonCodecMaker.make[DiffResultTestDetails](
+      CodecMakerConfig
+        .withTransientNone(false)
+        .withTransientDefault(false),
+    )
+  }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
Document test report run and test IDs. Publish documentation only for stable release tags.
<!-- gg:managed:end -->