### PR TITLE
TUI: persist search highlight after Enter

### DIFF
--- a/docs/docs/CLI.md
+++ b/docs/docs/CLI.md
@@ -41,6 +41,7 @@ Here are some TUI hotkeys. In general, vim-style keybindings are provided too.
 | <kbd>f</kbd> / <kbd>b</kbd> | Jump to the next or previous difference |
 | <kbd>/</kbd> | Search field names in the current diff |
 | <kbd>n</kbd> / <kbd>N</kbd> | Jump to the next or previous search result |
+| <kbd>F4</kbd> | Clear field search highlighting |
 | <kbd>Ctrl</kbd>+<kbd>P</kbd> | Open the test search window |
 | <kbd>a</kbd> | Anchor the selected subtree as the root. Useful if you want to "zoom in" on a particular part of the diff) |
 | <kbd>t</kbd> | Reset anchoring and return to showing the root of the diff |

--- a/modules/cli/src/main/scala/difflicious/cli/InteractiveReportViewer.scala
+++ b/modules/cli/src/main/scala/difflicious/cli/InteractiveReportViewer.scala
@@ -25,6 +25,7 @@ private[cli] object TerminalKey {
   case object NextDifference extends TerminalKey
   case object PreviousDifference extends TerminalKey
   case object FieldSearch extends TerminalKey
+  case object ClearSearchHighlights extends TerminalKey
   case object NextSearchResult extends TerminalKey
   case object PreviousSearchResult extends TerminalKey
   case object PageDown extends TerminalKey
@@ -65,6 +66,7 @@ private[cli] final case class TerminalKeymap(
   nextDifference: TerminalKeymap.Binding,
   previousDifference: TerminalKeymap.Binding,
   fieldSearch: TerminalKeymap.Binding,
+  clearSearchHighlights: TerminalKeymap.Binding,
   nextSearchResult: TerminalKeymap.Binding,
   previousSearchResult: TerminalKeymap.Binding,
   pageDown: TerminalKeymap.Binding,
@@ -91,6 +93,7 @@ private[cli] final case class TerminalKeymap(
       nextDifference,
       previousDifference,
       fieldSearch,
+      clearSearchHighlights,
       nextSearchResult,
       previousSearchResult,
       pageDown,
@@ -187,6 +190,12 @@ private[cli] object TerminalKeymap {
       nextDifference = bind(NextDifference, char('f')),
       previousDifference = bind(PreviousDifference, char('b')),
       fieldSearch = bind(FieldSearch, char('/')),
+      clearSearchHighlights = bind(
+        ClearSearchHighlights,
+        escape("OS", "F4"),
+        escape("[14~", "F4"),
+        escape("[[D", "F4"),
+      ),
       nextSearchResult = bind(NextSearchResult, char('n')),
       previousSearchResult = bind(PreviousSearchResult, char('N')),
       pageDown = bind(PageDown, escape("[6~", "page down")),
@@ -803,6 +812,9 @@ object InteractiveReportViewer extends TuiRunner {
         case TerminalKey.FieldSearch =>
           TerminalScreen.Diff(state.copy(fieldSearch = state.fieldSearch.copy(active = true)))
 
+        case TerminalKey.ClearSearchHighlights =>
+          TerminalScreen.Diff(state.copy(fieldSearch = state.fieldSearch.copy(submittedQuery = "")))
+
         case TerminalKey.NextSearchResult =>
           TerminalScreen.Diff(state.jumpToFieldSearchMatch(state.fieldSearch.submittedQuery, step = 1))
 
@@ -1076,16 +1088,15 @@ object InteractiveReportViewer extends TuiRunner {
     val start = windowStart(selectedIndex, rows.length, listRows)
     val visibleRows = rows.slice(start, start + listRows)
     val pathWidth = rowContentWidth(width)
-    val highlightedSearchIds =
-      if (fieldSearch.active) tree.fieldSearchIds(anchor, fieldSearch.query).toSet else Set.empty[Vector[String]]
+    val highlightQuery = fieldSearch.highlightQuery
+    val highlightedSearchIds = tree.fieldSearchIds(anchor, highlightQuery).toSet
     val visibleTreeIds = rows.iterator.map(_.node.id).toSet
     val descendantSearchCounts =
-      if (fieldSearch.active) tree.fieldSearchHiddenDescendantCounts(anchor, fieldSearch.query, visibleTreeIds)
-      else Map.empty[Vector[String], Int]
+      tree.fieldSearchHiddenDescendantCounts(anchor, highlightQuery, visibleTreeIds)
     val changeLines = visibleRows.zipWithIndex.map { case (row, offset) =>
       val index = start + offset
       val searchQuery =
-        if (highlightedSearchIds.contains(row.node.id)) Some(fieldSearch.query) else None
+        if (highlightedSearchIds.contains(row.node.id)) Some(highlightQuery) else None
       renderSelectableLine(
         renderDiffTreeRow(
           row,
@@ -1226,6 +1237,7 @@ object InteractiveReportViewer extends TuiRunner {
         ),
         "Search" -> Vector(
           helpLine(keymap.fieldSearch.label, "search current view"),
+          helpLine(keymap.clearSearchHighlights.label, "clear field search highlighting"),
           helpLine(keymap.search.label, "search tests with finder"),
         ),
         "Diff detail" -> Vector(
@@ -2089,6 +2101,9 @@ object InteractiveReportViewer extends TuiRunner {
   private[cli] final case class FieldSearchState(query: String, active: Boolean, submittedQuery: String) {
     def isVisible: Boolean =
       active
+
+    def highlightQuery: String =
+      if (active) query else submittedQuery
   }
 
   private[cli] object FieldSearchState {

--- a/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff screen question mark shows hotkey popup/01-hotkey-popup.snap
+++ b/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff screen question mark shows hotkey popup/01-hotkey-popup.snap
@@ -15,6 +15,7 @@
                  │                                                                │
                  │ Search                                                         │
                  │   /                       search current view                  │
+                 │   F4                      clear field search highlighting      │
                  │   ctrl-p                  search tests with finder             │
                  │                                                                │
                  │ Diff detail                                                    │
@@ -30,7 +31,6 @@
                  │   escape                  go back or confirm quit              │
                  │   ctrl-c or ctrl-d        quit immediately                     │
                  └────────────────────────────────────────────────────────────────┘
-
 
 
 

--- a/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/hotkey popup renders session keymap labels/01-hotkey-popup.snap
+++ b/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/hotkey popup renders session keymap labels/01-hotkey-popup.snap
@@ -15,6 +15,7 @@ No diff failures found.
                  │                                                                │
                  │ Search                                                         │
                  │   /                       search current view                  │
+                 │   F4                      clear field search highlighting      │
                  │   x                       search tests with finder             │
                  │                                                                │
                  │ Diff detail                                                    │
@@ -30,7 +31,6 @@ No diff failures found.
                  │   escape                  go back or confirm quit              │
                  │   ctrl-c or ctrl-d        quit immediately                     │
                  └────────────────────────────────────────────────────────────────┘
-
 
 
 

--- a/modules/cli/src/test/scala/difflicious/cli/InteractiveReportViewerSpec.scala
+++ b/modules/cli/src/test/scala/difflicious/cli/InteractiveReportViewerSpec.scala
@@ -456,6 +456,21 @@ class InteractiveReportViewerSpec extends FunSuite with SnapshotAssertions {
     )
   }
 
+  test("diff screen keeps submitted field search highlighted until F4 clears it") {
+    val report = DiffReport(Vector(fieldSearchDiffRun))
+    val testDriver = TestDriver(makeViewerState(report, color = true))
+
+    testDriver.pressKey(TerminalKey.FieldSearch)
+    testDriver.typeKeys("name")
+    testDriver.pressKey(SearchKey.Submit)
+
+    assert(testDriver.render.exists(_.contains("\u001b[43m")))
+
+    testDriver.pressKey(TerminalKey.ClearSearchHighlights)
+
+    assert(!testDriver.render.exists(_.contains("\u001b[43m")))
+  }
+
   test("diff screen n and shift-n navigate field search results") {
     val report = DiffReport(Vector(fieldSearchDiffRun))
     val testDriver = TestDriver(makeViewerState(report, color = false))


### PR DESCRIPTION
## Summary
- keep field-search matches highlighted after submitting with Enter
- bind F4 to clear submitted search highlighting
- document the shortcut and update the help snapshots

## Testing
- sbt --client "cli3/test"