### PR TITLE
Fix running TUI in various sbt modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Build project and docs
-        run: sbt 'test; docs/docusaurusCreateSite'
+        run: sbt 'test; docs/mdoc; docs/docusaurusCreateSite'
 
       - name: Compile sbt 2 plugin with fatal warnings
         run: sbt '++3.8.4; sbtPlugin / Compile / compile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Build project and docs
-        run: sbt 'test; docs/mdoc; docs/docusaurusCreateSite'
+        run: sbt 'test; docs/docusaurusCreateSite'
 
       - name: Compile sbt 2 plugin with fatal warnings
         run: sbt '++3.8.4; sbtPlugin / Compile / compile'

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import sbtghactions.JavaSpec
 import complete.DefaultParsers.*
 import sbt.Reference.display
+import sbt.util.CacheImplicits.given
 import org.typelevel.sbt.tpolecat.{CiMode, DevMode}
 import scala.concurrent.duration.*
 import scala.sys.process.Process
@@ -18,41 +19,18 @@ val hearthVersion = "0.4.1"
 val jsoniterScalaVersion = "2.40.1"
 
 val generateCompileBenchmarkSources = taskKey[Seq[File]]("Generate tracked compile benchmark sources")
+val generateMdoc = taskKey[xsbti.HashedVirtualFileRef]("Generate cached mdoc output")
+val mdocInputs = taskKey[Seq[xsbti.HashedVirtualFileRef]]("Mdoc input files")
+val mdocRunnerClasspath = taskKey[Seq[String]]("Classpath used to launch mdoc")
 
 def runWebsiteCommand(command: Seq[String], cwd: File, extraEnv: (String, String)*): Unit = {
-  val exit = Process(command, cwd, extraEnv*).!
+  val exit = Process(command, cwd, extraEnv *).!
   assert(exit == 0, s"command returned $exit: ${command.mkString(" ")}")
 }
 
-def markdownFiles(directory: File): Seq[File] =
-  Option(directory.listFiles).toSeq.flatten.flatMap { file =>
-    if (file.isDirectory) markdownFiles(file)
-    else if (file.getName.endsWith(".md")) Seq(file)
-    else Seq.empty
-  }
-
-def waitForMdocOutput(input: File, output: File): Unit = {
-  val expected = markdownFiles(input).map(file => input.toPath.relativize(file.toPath))
-  val deadline = 10.seconds.fromNow
-  var missing = expected.filterNot(path => output.toPath.resolve(path).toFile.isFile)
-  while (missing.nonEmpty && deadline.hasTimeLeft) {
-    Thread.sleep(50)
-    missing = expected.filterNot(path => output.toPath.resolve(path).toFile.isFile)
-  }
-  require(missing.isEmpty, s"mdoc output was not materialized: ${missing.mkString(", ")}")
-
-  var previous = Seq.empty[(Long, Long)]
-  var stable = false
-  while (!stable && deadline.hasTimeLeft) {
-    val current = expected.map { path =>
-      val file = output.toPath.resolve(path).toFile
-      file.length -> file.lastModified
-    }
-    stable = current == previous
-    previous = current
-    if (!stable) Thread.sleep(50)
-  }
-  require(stable, "mdoc output did not stabilize")
+def stageMdoc(generated: java.nio.file.Path, destination: File): Unit = {
+  IO.delete(destination)
+  IO.copyDirectory(generated.toFile, destination)
 }
 
 val isScala3 = Def.setting {
@@ -93,7 +71,7 @@ lazy val allModules =
   projectMatrixModules.flatMap(_.projectRefs) :+ LocalProject("sbtPlugin")
 
 lazy val difflicious = Project("difflicious", file("."))
-  .aggregate(allModules*)
+  .aggregate(allModules *)
   .settings(commonSettings, noPublishSettings)
 
 lazy val sbtPlugin = project
@@ -378,24 +356,55 @@ lazy val docs: ProjectMatrix = projectMatrix
   )
   .settings(
     mdocIn := file("docs/docs"),
-    mdocOut := file("docs/target/mdoc"),
+    mdocOut := (Compile / target).value / "mdoc",
     mdocVariables := Map("VERSION" -> sys.env.get("DOCS_VERSION").filter(_.nonEmpty).getOrElse(version.value)),
     mdocExtraArguments ++= Seq("--noLinkHygiene"),
-    docusaurusCreateSite := Def.taskDyn {
-      (Compile / mdoc).toTask(" ").value
-      val input = mdocIn.value
-      val output = mdocOut.value
-      val website = (ThisBuild / baseDirectory).value / "website"
-      Def.task {
-        waitForMdocOutput(input, output)
-        runWebsiteCommand(Seq("yarn", "install", "--immutable"), website)
-        runWebsiteCommand(Seq("yarn", "run", "build"), website)
-        website / "build"
-      }
-    }.value,
-    docusaurusPublishGhpages := Def.taskDyn {
-      (Compile / mdoc).toTask(" ").value
-      val website = (ThisBuild / baseDirectory).value / "website"
+    mdocInputs := Def.uncached {
+      val converter = fileConverter.value
+      ((mdocIn.value ** AllPassFilter).get() ++ (Compile / sources).value).distinct
+        .filter(_.isFile)
+        .sortBy(_.getAbsolutePath)
+        .map(file => converter.toVirtualFile(file.toPath))
+    },
+    mdocRunnerClasspath := Def.uncached {
+      val converter = fileConverter.value
+      (Compile / fullClasspath).value.map(entry => converter.toPath(entry.data).toString)
+    },
+    generateMdoc := {
+      val converter = fileConverter.value
+      val _ = mdocInputs.value
+      val _ = (Compile / dependencyClasspath).value
+      val _ = (Compile / scalacOptions).value
+      val _ = mdocVariables.value
+      val root = (ThisBuild / baseDirectory).value
+      val output = root.toPath.resolve(mdocOut.value.toPath).normalize
+      val javaExecutable = javaHome.value.fold("java")(home => (home / "bin" / "java").absolutePath)
+      val command =
+        Seq(javaExecutable, "-cp", mdocRunnerClasspath.value.mkString(java.io.File.pathSeparator), "mdoc.SbtMain") ++
+          mdocExtraArguments.value
+
+      IO.delete(output.toFile)
+      runWebsiteCommand(command, root)
+      require(output.toFile.isDirectory, s"mdoc did not create $output")
+
+      val generated = converter.toVirtualFile(output)
+      Def.declareOutputDirectory(generated)
+      generated
+    },
+    docusaurusCreateSite := {
+      val generated = fileConverter.value.toPath(generateMdoc.value)
+      val root = (ThisBuild / baseDirectory).value
+      val website = root / "website"
+      stageMdoc(generated, root / "docs/target/mdoc")
+      runWebsiteCommand(Seq("yarn", "install", "--immutable"), website)
+      runWebsiteCommand(Seq("yarn", "run", "build"), website)
+      website / "build"
+    },
+    docusaurusPublishGhpages := {
+      val generated = fileConverter.value.toPath(generateMdoc.value)
+      val root = (ThisBuild / baseDirectory).value
+      val website = root / "website"
+      stageMdoc(generated, root / "docs/target/mdoc")
       val publishEnv = Seq(
         "GIT_USER" -> sys.env.getOrElse("GIT_USER", "jatcwang"),
         "GIT_PASS" -> sys.env.getOrElse("GIT_PASS", sys.env.getOrElse("GITHUB_TOKEN", "")),
@@ -405,11 +414,9 @@ lazy val docs: ProjectMatrix = projectMatrix
           "jatcwang@gmail.com",
         ),
       ).filter(_._2.nonEmpty)
-      Def.task {
-        runWebsiteCommand(Seq("yarn", "install", "--immutable"), website)
-        runWebsiteCommand(Seq("yarn", "run", "publish-gh-pages"), website, publishEnv*)
-      }
-    }.value,
+      runWebsiteCommand(Seq("yarn", "install", "--immutable"), website)
+      runWebsiteCommand(Seq("yarn", "run", "publish-gh-pages"), website, publishEnv *)
+    },
   )
   .settings(
     // Disable any2stringAdd deprecation in md files. Seems like mdoc macro generates code which

--- a/build.sbt
+++ b/build.sbt
@@ -350,14 +350,16 @@ lazy val docs: ProjectMatrix = projectMatrix
     mdocOut := file("docs/target/mdoc"),
     mdocVariables := Map("VERSION" -> sys.env.get("DOCS_VERSION").filter(_.nonEmpty).getOrElse(version.value)),
     mdocExtraArguments ++= Seq("--noLinkHygiene"),
-    docusaurusCreateSite := {
+    docusaurusCreateSite := Def.taskDyn {
       (Compile / mdoc).toTask(" ").value
       val website = (ThisBuild / baseDirectory).value / "website"
-      runWebsiteCommand(Seq("yarn", "install", "--immutable"), website)
-      runWebsiteCommand(Seq("yarn", "run", "build"), website)
-      website / "build"
-    },
-    docusaurusPublishGhpages := {
+      Def.task {
+        runWebsiteCommand(Seq("yarn", "install", "--immutable"), website)
+        runWebsiteCommand(Seq("yarn", "run", "build"), website)
+        website / "build"
+      }
+    }.value,
+    docusaurusPublishGhpages := Def.taskDyn {
       (Compile / mdoc).toTask(" ").value
       val website = (ThisBuild / baseDirectory).value / "website"
       val publishEnv = Seq(
@@ -369,9 +371,11 @@ lazy val docs: ProjectMatrix = projectMatrix
           "jatcwang@gmail.com",
         ),
       ).filter(_._2.nonEmpty)
-      runWebsiteCommand(Seq("yarn", "install", "--immutable"), website)
-      runWebsiteCommand(Seq("yarn", "run", "publish-gh-pages"), website, publishEnv*)
-    },
+      Def.task {
+        runWebsiteCommand(Seq("yarn", "install", "--immutable"), website)
+        runWebsiteCommand(Seq("yarn", "run", "publish-gh-pages"), website, publishEnv*)
+      }
+    }.value,
   )
   .settings(
     // Disable any2stringAdd deprecation in md files. Seems like mdoc macro generates code which

--- a/build.sbt
+++ b/build.sbt
@@ -511,7 +511,7 @@ ThisBuild / githubWorkflowJobSetup :=
 
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(
-    List("test", "docs/docusaurusCreateSite"),
+    List("test", "docs/mdoc", "docs/docusaurusCreateSite"),
     name = Some("Build project and docs"),
   ),
   WorkflowStep.Sbt(

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,37 @@ def runWebsiteCommand(command: Seq[String], cwd: File, extraEnv: (String, String
   assert(exit == 0, s"command returned $exit: ${command.mkString(" ")}")
 }
 
+def markdownFiles(directory: File): Seq[File] =
+  Option(directory.listFiles).toSeq.flatten.flatMap { file =>
+    if (file.isDirectory) markdownFiles(file)
+    else if (file.getName.endsWith(".md")) Seq(file)
+    else Seq.empty
+  }
+
+def waitForMdocOutput(input: File, output: File): Unit = {
+  val expected = markdownFiles(input).map(file => input.toPath.relativize(file.toPath))
+  val deadline = 10.seconds.fromNow
+  var missing = expected.filterNot(path => output.toPath.resolve(path).toFile.isFile)
+  while (missing.nonEmpty && deadline.hasTimeLeft) {
+    Thread.sleep(50)
+    missing = expected.filterNot(path => output.toPath.resolve(path).toFile.isFile)
+  }
+  require(missing.isEmpty, s"mdoc output was not materialized: ${missing.mkString(", ")}")
+
+  var previous = Seq.empty[(Long, Long)]
+  var stable = false
+  while (!stable && deadline.hasTimeLeft) {
+    val current = expected.map { path =>
+      val file = output.toPath.resolve(path).toFile
+      file.length -> file.lastModified
+    }
+    stable = current == previous
+    previous = current
+    if (!stable) Thread.sleep(50)
+  }
+  require(stable, "mdoc output did not stabilize")
+}
+
 val isScala3 = Def.setting {
   // doesn't work well with >= 3.0.0 for `3.0.0-M1`
   scalaVersion.value.startsWith("3")
@@ -352,8 +383,11 @@ lazy val docs: ProjectMatrix = projectMatrix
     mdocExtraArguments ++= Seq("--noLinkHygiene"),
     docusaurusCreateSite := Def.taskDyn {
       (Compile / mdoc).toTask(" ").value
+      val input = mdocIn.value
+      val output = mdocOut.value
       val website = (ThisBuild / baseDirectory).value / "website"
       Def.task {
+        waitForMdocOutput(input, output)
         runWebsiteCommand(Seq("yarn", "install", "--immutable"), website)
         runWebsiteCommand(Seq("yarn", "run", "build"), website)
         website / "build"
@@ -511,7 +545,7 @@ ThisBuild / githubWorkflowJobSetup :=
 
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(
-    List("test", "docs/mdoc", "docs/docusaurusCreateSite"),
+    List("test", "docs/docusaurusCreateSite"),
     name = Some("Build project and docs"),
   ),
   WorkflowStep.Sbt(

--- a/modules/cli/src/main/scala/difflicious/cli/InteractiveReportViewer.scala
+++ b/modules/cli/src/main/scala/difflicious/cli/InteractiveReportViewer.scala
@@ -254,7 +254,7 @@ object InteractiveReportViewer extends TuiRunner {
     var session: JLineTerminalSession = null
 
     try {
-      terminal = TerminalBuilder.builder().name("difflicious").system(true).build()
+      terminal = TerminalBuilder.builder().name("difflicious").system(true).devTty(true).build()
       originalAttributes = terminal.enterRawMode()
       session = new JLineTerminalSession(terminal, TerminalKeymap.default)
       session.enterFullscreen()

--- a/modules/sbt-plugin/src/main/scala-sbt-1.0/difflicious/sbt/ClientJobCompat.scala
+++ b/modules/sbt-plugin/src/main/scala-sbt-1.0/difflicious/sbt/ClientJobCompat.scala
@@ -6,12 +6,35 @@ import sbt.internal.server.ClientJob
 
 private[sbt] object ClientJobCompat {
   def configurationSettings(configuration: Configuration): Seq[Def.Setting[_]] =
-    inConfig(configuration)(ClientJob.configSettings)
+    inConfig(configuration)(
+      ClientJob.configSettings ++
+        Seq(
+          Keys.run := Defaults
+            .runTask(fullClasspath, Def.task(Some("difflicious.cli.Main")), Keys.run / runner)
+            .evaluated,
+        ) ++
+        inTask(Keys.run)(Defaults.runnerSettings),
+    )
 
   def run(
     project: ProjectRef,
     configuration: Configuration,
     arguments: String,
-  ): Def.Initialize[Task[Unit]] =
-    (project / configuration / clientJobRunInfo).toTask(s" $arguments").map(_ => ())
+  ): Def.Initialize[Task[Unit]] = Def.taskDyn {
+    val runArguments = s" $arguments"
+    val isNetworkClient =
+      state.value.currentCommand.flatMap(_.source).exists(_.channelName.startsWith("network"))
+
+    if (isNetworkClient)
+      (project / configuration / clientJobRunInfo).toTask(runArguments).map(_ => ())
+    else {
+      val scope = Scope(
+        Select(project),
+        Select(ConfigKey(configuration.name)),
+        Zero,
+        Zero,
+      )
+      Scoped.scopedInput(scope, Keys.run.key).toTask(runArguments).map(_ => ())
+    }
+  }
 }

--- a/modules/sbt-plugin/src/main/scala-sbt-2/sbt/DiffliciousClientJobCompat.scala
+++ b/modules/sbt-plugin/src/main/scala-sbt-2/sbt/DiffliciousClientJobCompat.scala
@@ -4,5 +4,9 @@ import sbt.internal.RunUtil
 
 object DiffliciousClientJobCompat {
   def settings(configuration: Configuration): Seq[Def.Setting[?]] =
-    RunUtil.configTasks(ScopeAxis.Select(ConfigKey(configuration.name)))
+    RunUtil.configTasks(ScopeAxis.Select(ConfigKey(configuration.name))) ++ Seq(
+      Keys.run / Keys.runner := Def.uncached {
+        new ForkRun((Keys.run / Keys.forkOptions).value)
+      },
+    )
 }


### PR DESCRIPTION
## Summary

- run the viewer directly from ordinary sbt 1 shells while preserving thin-client client jobs
- force a forked runner under sbt 2 to avoid JLine classpath conflicts
- use JLine’s controlling-terminal fallback so forked viewers inherit full terminal dimensions
- Update CI to wait for mdoc files to appear on file system before running yarn to build the website

## Testing

- `sbt --client "++2.12.21 ; sbtPlugin / scripted difflicious/mixed-fork-nonfork-modules"`
- `sbt --client "++3.8.4 ; sbtPlugin / scripted difflicious/mixed-fork-nonfork-modules"`
- `sbt --client "cli3 / test"`
- manually verified `diffliciousViewer` with the sbt 1 client, sbt 1 shell, and sbt 2 shell, including terminal resizing