### PR TITLE
Fix native artifact path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,8 @@ jobs:
       - name: Verify and stage native image
         run: |
           set -euo pipefail
-          binary="modules/cli/target/jvm-3/graalvm-native-image/difflicious"
+          binary="$(find target/out -type f -path '*/difflicious-cli/graalvm-native-image/difflicious' -print -quit)"
+          test -n "$binary"
           test -x "$binary"
           "$binary" --help >/dev/null
           mkdir -p dist

--- a/build.sbt
+++ b/build.sbt
@@ -551,7 +551,8 @@ ThisBuild / githubWorkflowAddedJobs := Seq(
       WorkflowStep.Run(
         List(
           "set -euo pipefail",
-          "binary=\"modules/cli/target/jvm-3/graalvm-native-image/difflicious\"",
+          "binary=\"$(find target/out -type f -path '*/difflicious-cli/graalvm-native-image/difflicious' -print -quit)\"",
+          "test -n \"$binary\"",
           "test -x \"$binary\"",
           "\"$binary\" --help >/dev/null",
           "mkdir -p dist",


### PR DESCRIPTION
The native image is now emitted under the centralized `target/out` layout, but CI still checked the old module-local target path. Discover the generated executable in its native-image output subtree before staging it.

The final commit temporarily enables the native build for this PR branch so the full native matrix can verify the fix. It should be removed before merge.

Local verification:
- `cli3/test` (74 tests)
- `cli3/GraalVMNativeImage/packageBin`
- native binary execution and artifact checksum staging
- generated workflow consistency