### PR TITLE
Show seconds ago for TUI run timestamps under 2 minutes

### DIFF
--- a/modules/cli/src/main/scala/difflicious/cli/InteractiveReportViewer.scala
+++ b/modules/cli/src/main/scala/difflicious/cli/InteractiveReportViewer.scala
@@ -1991,14 +1991,20 @@ object InteractiveReportViewer extends TuiRunner {
       .getOrElse("unknown time")
 
   private[cli] def timestampLabel(millis: Long, now: Instant, zoneId: ZoneId): String = {
-    val timestamp = Instant.ofEpochMilli(millis).atZone(zoneId)
-    val today = LocalDate.ofInstant(now, zoneId)
-    val time = timestamp.format(DateTimeFormatter.ofPattern("h:mma", Locale.ENGLISH)).toLowerCase(Locale.ENGLISH)
-    val dateLabel =
-      if (timestamp.toLocalDate == today) "Today"
-      else if (timestamp.toLocalDate == today.minusDays(1)) "Yesterday"
-      else timestamp.format(DateTimeFormatter.ofPattern("MMM d (EEE)", Locale.ENGLISH))
-    s"$dateLabel $time"
+    val seconds = Math.max(0L, (now.toEpochMilli - millis) / 1000L)
+    if (seconds < 2 * 60)
+      if (seconds == 1L) "1 second ago"
+      else s"$seconds seconds ago"
+    else {
+      val timestamp = Instant.ofEpochMilli(millis).atZone(zoneId)
+      val today = LocalDate.ofInstant(now, zoneId)
+      val time = timestamp.format(DateTimeFormatter.ofPattern("h:mma", Locale.ENGLISH)).toLowerCase(Locale.ENGLISH)
+      val dateLabel =
+        if (timestamp.toLocalDate == today) "Today"
+        else if (timestamp.toLocalDate == today.minusDays(1)) "Yesterday"
+        else timestamp.format(DateTimeFormatter.ofPattern("MMM d (EEE)", Locale.ENGLISH))
+      s"$dateLabel $time"
+    }
   }
 
   private def renderDiffTreeRow(

--- a/modules/cli/src/test/scala/difflicious/cli/InteractiveReportViewerSpec.scala
+++ b/modules/cli/src/test/scala/difflicious/cli/InteractiveReportViewerSpec.scala
@@ -118,6 +118,28 @@ class InteractiveReportViewerSpec extends FunSuite with SnapshotAssertions {
     testDriver.assertSnapshot("test-finder")
   }
 
+  test("timestamp label shows seconds ago for runs under two minutes old") {
+    val zone = ZoneId.of("Europe/London")
+    val timestamp = Instant.parse("2026-07-15T09:15:10Z")
+    val now = Instant.parse("2026-07-15T09:16:20Z")
+
+    assertEquals(
+      InteractiveReportViewer.timestampLabel(timestamp.toEpochMilli, now, zone),
+      "70 seconds ago",
+    )
+  }
+
+  test("timestamp label shows one second ago for a run one second old") {
+    val zone = ZoneId.of("Europe/London")
+    val timestamp = Instant.parse("2026-07-15T09:15:10Z")
+    val now = Instant.parse("2026-07-15T09:15:11Z")
+
+    assertEquals(
+      InteractiveReportViewer.timestampLabel(timestamp.toEpochMilli, now, zone),
+      "1 second ago",
+    )
+  }
+
   test("timestamp label describes a local timestamp from today") {
     val zone = ZoneId.of("Europe/London")
     val timestamp = Instant.parse("2026-07-15T09:15:10Z")


### PR DESCRIPTION
TUI: run timestamps under 2 minutes now display as "X seconds ago" instead of the date/time label.