### PR TITLE
TUI: Remove unnecessary +/- in front of fields

### DIFF
--- a/modules/cli/src/main/scala/difflicious/cli/InteractiveReportViewer.scala
+++ b/modules/cli/src/main/scala/difflicious/cli/InteractiveReportViewer.scala
@@ -2623,9 +2623,9 @@ object InteractiveReportViewer extends TuiRunner {
         case DiffResult.ValueResult.Both(_, obtained, expected, isSame, _) =>
           if (isSame) obtained else s"$obtained -> $expected"
         case DiffResult.ValueResult.ObtainedOnly(_, obtained, _) =>
-          s"+ $obtained"
+          obtained
         case DiffResult.ValueResult.ExpectedOnly(_, expected, _) =>
-          s"- $expected"
+          expected
       }
 
     private def decodeMapKey(key: String): String =

--- a/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-default-expanded-side-only-root.snap
+++ b/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-default-expanded-side-only-root.snap
@@ -1,5 +1,5 @@
 > ▾ RootOnlyRecord                                                                                 <
-      name: + Ada                                                                                   
+      name: Ada                                                                                     
 
 
 

--- a/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-expanded-both-side-only-records.snap
+++ b/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-expanded-both-side-only-records.snap
@@ -1,8 +1,8 @@
   ▾ SideOnlyFixture                                                                                 
     ▾ actualOnly  : ActualOnlyRecord                                                                
-        name: + Ada                                                                                 
+        name: Ada                                                                                   
 >   ▾ expectedOnly: ExpectedOnlyRecord                                                             <
-        name: - Grace                                                                               
+        name: Grace                                                                                 
 
 
 

--- a/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-expanded-side-only-record.snap
+++ b/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-expanded-side-only-record.snap
@@ -1,6 +1,6 @@
   ▾ SideOnlyFixture                                                                                 
     ▾ actualOnly  : ActualOnlyRecord                                                                
->       name: + Ada                                                                                <
+>       name: Ada                                                                                  <
     ▸ expectedOnly: ExpectedOnlyRecord                                                              
 
 

--- a/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-explicitly-expanded-side-only-root.snap
+++ b/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-explicitly-expanded-side-only-root.snap
@@ -1,5 +1,5 @@
   ▾ RootOnlyRecord                                                                                  
->     name: + Ada                                                                                  <
+>     name: Ada                                                                                    <
 
 
 

--- a/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-list-extra-and-missing-collapsed.snap
+++ b/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-list-extra-and-missing-collapsed.snap
@@ -1,0 +1,39 @@
+  ▾ List[TuiListElement]                                                                            
+    ▸ [0]: TuiListElement                                                                           
+>   ▸ [1]: TuiListElement                                                                          <
+    ▸ [2]: TuiListElement                                                                           
+    ▸ [3]: TuiListElement                                                                           
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-list-extra-and-missing-expanded.snap
+++ b/modules/cli/src/test/resources/snapshot/InteractiveReportViewerSpec/diff-screen-list-extra-and-missing-expanded.snap
@@ -1,0 +1,39 @@
+  ▾ List[TuiListElement]                                                                            
+    ▸ [0]: TuiListElement                                                                           
+    ▾ [1]: TuiListElement                                                                           
+        sku        : "SKU-EXTRA"                                                                    
+        description: "Extra lid"                                                                    
+        quantity   : 1                                                                              
+    ▸ [2]: TuiListElement                                                                           
+>   ▾ [3]: TuiListElement                                                                          <
+        sku        : "SKU-MISSING"                                                                  
+        description: "Missing cap"                                                                  
+        quantity   : 3                                                                              
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/modules/cli/src/test/scala/difflicious/cli/InteractiveReportViewerSpec.scala
+++ b/modules/cli/src/test/scala/difflicious/cli/InteractiveReportViewerSpec.scala
@@ -1,6 +1,8 @@
 package difflicious.cli
 
+import difflicious.Differ
 import difflicious.DiffResult
+import difflicious.implicits.toPairByOps
 import difflicious.PairType
 import difflicious.utils.TypeName
 import io.circe.parser.parse
@@ -847,6 +849,29 @@ class InteractiveReportViewerSpec extends FunSuite with SnapshotAssertions {
     )
   }
 
+  test("diff screen shows list with one extra and one missing case class element") {
+    val report = DiffReport(Vector(listWithExtraAndMissingRun))
+    val testDriver = TestDriver(makeViewerState(report, color = false))
+
+    assertFileSnapshot(
+      snapshotLines(testDriver.render),
+      "InteractiveReportViewerSpec/diff-screen-list-extra-and-missing-collapsed.snap",
+    )
+
+    testDriver.pressKeys(
+      TerminalKey.Expand,
+      TerminalKey.NextDifference,
+      TerminalKey.NextDifference,
+      TerminalKey.NextDifference,
+      TerminalKey.NextDifference,
+      TerminalKey.Expand,
+    )
+    assertFileSnapshot(
+      snapshotLines(testDriver.render),
+      "InteractiveReportViewerSpec/diff-screen-list-extra-and-missing-expanded.snap",
+    )
+  }
+
   test("diff screen right pads record fields to the longest field name") {
     val report = DiffReport(Vector(paddedRecordDiffRun))
     val testDriver = TestDriver(makeViewerState(report, color = false))
@@ -1207,6 +1232,21 @@ class InteractiveReportViewerSpec extends FunSuite with SnapshotAssertions {
       metadata = None,
     )
 
+  private def listWithExtraAndMissingRun: DiffRun = {
+    val obtained = List(
+      TuiListElement("SKU-RED", "Red travel mug", 1),
+      TuiListElement("SKU-EXTRA", "Extra lid", 1),
+      TuiListElement("SKU-BLUE", "Blue bottle", 2),
+    )
+    val expected = List(
+      TuiListElement("SKU-RED", "Red travel mug", 1),
+      TuiListElement("SKU-MISSING", "Missing cap", 3),
+      TuiListElement("SKU-BLUE", "Blue bottle", 2),
+    )
+    val result = Differ[List[TuiListElement]].pairBy(_.sku).diff(obtained, expected)
+    DiffRun.fromResult(result, metadata = None)
+  }
+
   private def lineContaining(lines: Vector[String], text: String): String =
     lines.find(_.contains(text)).getOrElse(fail(s"Could not find line containing $text"))
 
@@ -1343,3 +1383,5 @@ class InteractiveReportViewerSpec extends FunSuite with SnapshotAssertions {
       value.sliding(needle.length).count(_ == needle)
 
 }
+
+private final case class TuiListElement(sku: String, description: String, quantity: Int) derives Differ


### PR DESCRIPTION
Removes the + / - prefixes on fields of obtained-only / expected-only case class values in the TUI diff tree, and adds snapshot coverage for a list with 1 extra + 1 missing case class element (both expanded).