### PR TITLE
Upgrade to Scala 3.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: sbt 'test; docs/mdoc; docs/docusaurusCreateSite'
 
       - name: Compile sbt 2 plugin with fatal warnings
-        run: sbt '++3.8.4; sbtPlugin / Compile / compile'
+        run: sbt '++3.9.0; sbtPlugin / Compile / compile'
 
   publish:
     name: Publish Artifacts

--- a/modules/sbt-plugin/src/sbt-test/difflicious/mixed-fork-nonfork-modules/build.sbt
+++ b/modules/sbt-plugin/src/sbt-test/difflicious/mixed-fork-nonfork-modules/build.sbt
@@ -2,7 +2,7 @@ import difflicious.sbt.DiffliciousPlugin.autoImport.*
 import difflicious.sbt.DiffliciousPlugin.SysPropNames
 import sbtcompat.PluginCompat.*
 
-ThisBuild / scalaVersion := "3.8.4"
+ThisBuild / scalaVersion := "3.9.0"
 
 val testDependencies = Seq(
   "com.github.jatcwang" %% "difflicious-scalatest" % sys.props("plugin.version"),

--- a/modules/sbt-plugin/src/sbt-test/difflicious/munit-jsonl/build.sbt
+++ b/modules/sbt-plugin/src/sbt-test/difflicious/munit-jsonl/build.sbt
@@ -1,7 +1,7 @@
 import difflicious.sbt.DiffliciousPlugin.autoImport.*
 import sbtcompat.PluginCompat.*
 
-ThisBuild / scalaVersion := "3.8.4"
+ThisBuild / scalaVersion := "3.9.0"
 ThisBuild / diffliciousCliAutoDependency := false
 
 libraryDependencies ++= Seq(

--- a/modules/sbt-plugin/src/sbt-test/difflicious/weaver-jsonl/build.sbt
+++ b/modules/sbt-plugin/src/sbt-test/difflicious/weaver-jsonl/build.sbt
@@ -1,7 +1,7 @@
 import difflicious.sbt.DiffliciousPlugin.autoImport.*
 import sbtcompat.PluginCompat.*
 
-ThisBuild / scalaVersion := "3.8.4"
+ThisBuild / scalaVersion := "3.9.0"
 ThisBuild / diffliciousCliAutoDependency := false
 
 libraryDependencies ++= Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object Build {
 
   val Scala212 = "2.12.21"
   val Scala213 = "2.13.18"
-  val Scala3 = "3.8.4"
+  val Scala3 = "3.9.0"
 
   // copied from: https://github.com/disneystreaming/smithy4s/blob/21a6fb04ab3485c0a4b40fe205a628c6f4750813/project/Smithy4sBuildPlugin.scala#L508
   def createBuildCommands(projects: Seq[ProjectReference]) = {


### PR DESCRIPTION
Bump Scala 3 from 3.8.4 to 3.9.0 (LTS). Updates project/Build.scala, scripted-test pins, and regenerated CI workflow. Verified with test_3_0_jvm.