### PR TITLE
Add snapshot publish command

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -74,6 +74,26 @@ object Build {
       }
     }
 
-    cmds
+    val jvmProjects = all.collect { case (Doublet(_, "jvm"), projects) =>
+      projects
+    }.flatten
+
+    cmds :+ publishLocalSnapshotCommand(jvmProjects)
   }
+
+  // Quick local development command to run publishLocal for all JVM projects
+  def publishLocalSnapshotCommand(
+    projects: Seq[String],
+    snapshotVersion: String = "0.7.0-SNAPSHOT",
+  ): Command =
+    Command.command("jvmPublishLocal") { state =>
+      val matrixPublishes = projects.map(project => s"$project/publishLocal")
+      // `+` cross-builds sbtPlugin over crossScalaVersions, publishing both
+      // the sbt 1.x (Scala 2.12) and sbt 2.x (Scala 3) variants.
+      val allPublishes = matrixPublishes :+ "+ sbtPlugin/publishLocal"
+      val setVersionCmd = s"""set ThisBuild / version := "$snapshotVersion""""
+      (setVersionCmd +: allPublishes).reverse.foldLeft(state) { (st, cmd) =>
+        cmd :: st
+      }
+    }
 }


### PR DESCRIPTION
Adds a `publishLocalSnapshot` sbt command that:

- sets `ThisBuild / version` to `0.7.0-SNAPSHOT`
- publishes JVM matrix projects only
- publishes both sbt 1 and sbt 2 plugin variants

Verified with `sbt --client "scalafmtSbtCheck ; publishLocalSnapshot"`.